### PR TITLE
fix(transformation): fix html_entity_decode bug

### DIFF
--- a/src/transformation/ragel/html_entity_decode.rl
+++ b/src/transformation/ragel/html_entity_decode.rl
@@ -88,7 +88,7 @@ void emitNumericEntity(char** r, const std::string& entity_value, bool is_hex) {
   } catch (...) {
     memcpy(*r, "&#", 2);
     *r += 2;
-    memcpy(r, entity_value.data(), entity_value.size());
+    memcpy(*r, entity_value.data(), entity_value.size());
     *r += entity_value.size();
     **r = ';';
     (*r)++;

--- a/test/transformation/transformation_test.cc
+++ b/test/transformation/transformation_test.cc
@@ -363,6 +363,15 @@ TEST_F(TransformationTest, htmlEntityDecode) {
     EXPECT_TRUE(ret);
     EXPECT_EQ(result, "& < > \" '   &notValid;");
   }
+
+  // Test for not valid html entity with invalid number
+  {
+    std::string data = "&#23234234234234;";
+    std::string result;
+    bool ret = html_entity_decode.evaluate(data, result);
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(result, data);
+  }
 }
 
 TEST_F(TransformationTest, jsDecode) {


### PR DESCRIPTION
Fix memory corruption in html_entity_decode function when decoding &#23234234234234;

Fixes #19