### PR TITLE
fix(transformation): fix normalize_path parsing differences (issue #48)

### DIFF
--- a/src/transformation/ragel/normalize_path.rl
+++ b/src/transformation/ragel/normalize_path.rl
@@ -75,16 +75,29 @@
 
   # prescan
   main := |*
+    SLASH DOT+ [^./] => skip; 
     SLASH DOT DOT => exec_transformation;
     SLASH DOT => exec_transformation;
     SLASH SLASH => exec_transformation;
+    DOT [^./] => skip;
     DOT => exec_transformation_if_start_with_dot;
     any => skip;
   *|;
 
   transformation := |*
+
+    SLASH+ DOT+ [^./] => {
+      *r++ = SLASH;
+      *r++ = '.';
+      fhold;
+    };
     SLASH+ DOT DOT {
-      removeLastDir(r, result.data()); 
+      if (ts == ps ) {
+        *r++ = SLASH;
+      } else {
+        removeLastDir(r, result.data()); 
+      }
+
       NORMALIZE_PATH_LOG(std::format("SLASH+ DOT DOT:{}",std::string_view(result.data(), r - result.data())));
     };
     SLASH+ DOT => { 
@@ -113,7 +126,7 @@
   *|;
 
   transformation_if_start_with_dot := |*
-    DOT SLASH* => {
+    DOT SLASH+ => {
       fgoto transformation;
     };
     DOT DOT => {


### PR DESCRIPTION
This commit modifies the parsing logic of normlaize_path.rl, which is basically aligned with the effect of modsecurity's conversion function.

fix: https://github.com/stone-rhino/wge/issues/48