### PR TITLE
fix(variable): correct REQUEST_BASENAME evaluation using request_line_info_'s base_name_

### DIFF
--- a/src/variable/request_basename.h
+++ b/src/variable/request_basename.h
@@ -34,16 +34,11 @@ public:
 public:
   void evaluate(Transaction& t, Common::EvaluateResults& result) const override {
     if (is_counter_) [[unlikely]] {
-      result.append(t.getRequestLineInfo().uri_.empty() ? 0 : 1);
+      result.append(t.getRequestLineInfo().base_name_.empty() ? 0 : 1);
       return;
     }
-
-    auto pos = t.getRequestLineInfo().uri_.rfind('/');
-    if (pos == std::string_view::npos) {
-      result.append(t.getRequestLineInfo().uri_);
-    } else {
-      result.append(t.getRequestLineInfo().uri_.substr(pos + 1));
-    }
+    
+    result.append(t.getRequestLineInfo().base_name_);
   }
 };
 } // namespace Variable


### PR DESCRIPTION
This pull request fixes an issue where `REQUEST_BASENAME` was incorrectly evaluated when the URI contained a query string. Previously, the `evaluate` function extracted the basename by slicing the URI after the last `/`, which included the query string (e.g., `index.js?id=1`). This led to unexpected rule mismatches.

fix https://github.com/stone-rhino/wge/issues/50