### PR TITLE
fix(transformation): fix html_entity_decode fails on leading zeros (issue: #58)

### DIFF
--- a/src/transformation/ragel/html_entity_decode.rl
+++ b/src/transformation/ragel/html_entity_decode.rl
@@ -62,10 +62,10 @@
     '&quot;' => exec_transformation;
     '&apos;' => exec_transformation;
     '&nbsp;' => exec_transformation;
-    '&#' [0-9]{1,7} [^0-9a-fA-F] => exec_transformation;
-    '&#x' [0-9a-fA-F]{1,6} [^0-9a-fA-F] => exec_transformation;
-    '&#' [0-9]{1,7} => exec_transformation_if_eof;
-    '&#x' [0-9a-fA-F]{1,6} => exec_transformation_if_eof;
+    '&#' '0'* [0-9]{1,7} [^0-9a-fA-F] => exec_transformation;
+    '&#' [xX] '0'* [0-9a-fA-F]{1,6} [^0-9a-fA-F] => exec_transformation;
+    '&#' '0'* [0-9]{1,7} => exec_transformation_if_eof;
+    '&#' [xX] '0'* [0-9a-fA-F]{1,6} => exec_transformation_if_eof;
     any => {};
   *|;
 
@@ -76,7 +76,7 @@
     '&quot;' => { *r++ = '"';};
     '&apos;' => { *r++ = '\'';};
     '&nbsp;' => { *r++ = ' ';};
-    '&#' [0-9]{1,7} [^0-9a-fA-F] => {
+    '&#' '0'* [0-9]{1,7} [^0-9a-fA-F] => {
       is_hex = false;
       entity_value = std::string(ts + 2, te - ts - 3);
       emitNumericEntity(&r, entity_value, is_hex);
@@ -84,7 +84,7 @@
         fhold;
       }
     };
-    '&#x' [0-9a-fA-F]{1,6} [^0-9a-fA-F] => {
+    '&#' [xX] '0'* [0-9a-fA-F]{1,6} [^0-9a-fA-F] => {
       is_hex = true;
       entity_value = std::string(ts + 3, te - ts - 4);
       emitNumericEntity(&r, entity_value, is_hex);
@@ -92,14 +92,14 @@
         fhold;
       }
     };
-    '&#' [0-9]{1,7} => {
+    '&#' '0'* [0-9]{1,7} => {
       if( te == eof ) {
         is_hex = false;
         entity_value = std::string(ts + 2, te - ts - 2);
         emitNumericEntity(&r, entity_value, is_hex);
       }
     };
-    '&#x' [0-9a-fA-F]{1,6} => {
+    '&#' [xX] '0'* [0-9a-fA-F]{1,6} => {
       if( te == eof ) {
         is_hex = true;
         entity_value = std::string(ts + 3, te - ts - 3);


### PR DESCRIPTION
This commit fixes the problem that html entity decode cannot parse and put a lot of 0s in front of the entity number to bypass decoding, and now the x in hexadecimal &#x is case-insensitive.

fix: https://github.com/stone-rhino/wge/issues/58