### PR TITLE
feat: build wge as shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,3 +34,7 @@ install(
   DESTINATION include/wge
   FILES_MATCHING PATTERN "*.h"
 )
+
+install(
+  TARGETS wge_shared
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,3 +29,40 @@ add_library(wge
 
 find_package(spdlog CONFIG REQUIRED)
 target_link_libraries(wge PRIVATE spdlog::spdlog_header_only)
+
+# Shared library
+add_library(wge_shared SHARED
+  $<TARGET_OBJECTS:action>
+  $<TARGET_OBJECTS:antlr4>
+  $<TARGET_OBJECTS:common>
+  $<TARGET_OBJECTS:common_ragel>
+  $<TARGET_OBJECTS:macro>
+  $<TARGET_OBJECTS:operator>
+  $<TARGET_OBJECTS:variable>
+  $<TARGET_OBJECTS:persistent_storage>
+  $<TARGET_OBJECTS:transformation>
+  ${local_source}
+)
+
+target_link_libraries(wge_shared PUBLIC spdlog::spdlog_header_only)
+
+find_package(antlr4-runtime CONFIG REQUIRED)
+target_link_libraries(wge_shared PRIVATE antlr4_static)
+
+find_library(INJECTION_LIB injection)
+target_link_libraries(wge_shared PRIVATE ${INJECTION_LIB})
+
+find_package(re2 CONFIG REQUIRED)
+target_link_libraries(wge_shared PRIVATE re2::re2)
+
+find_package(pcre2 CONFIG REQUIRED)
+target_link_libraries(wge_shared PRIVATE PCRE2::8BIT)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(HYPERSCAN REQUIRED libhs)
+target_link_directories(wge_shared PRIVATE ${HYPERSCAN_LIBRARY_DIRS})
+target_link_libraries(wge_shared PRIVATE ${HYPERSCAN_LIBRARIES})
+
+# Set consistent output names (only filename differs by suffix)
+set_target_properties(wge PROPERTIES OUTPUT_NAME "wge")
+set_target_properties(wge_shared PROPERTIES OUTPUT_NAME "wge")


### PR DESCRIPTION
# feat: Add shared library build target

## Summary
Enable building wge as shared library (`libwge.so`) in addition to existing static library.

## Changes
- Add `wge_shared` CMake target compiling all objects into dynamic library
- Link all required dependencies (antlr4, re2, PCRE2, Hyperscan, injection, spdlog)
- Maintain consistent output naming between static and shared variants
- Add installation support for shared library

Resolves https://github.com/stone-rhino/wge/issues/74