### PR TITLE
fix(operator): fix rx crash on invalid regex

### DIFF
--- a/src/common/pcre/scanner.cc
+++ b/src/common/pcre/scanner.cc
@@ -65,7 +65,7 @@ const Pattern* Scanner::getPattern(uint64_t id) {
 void Scanner::match(std::string_view subject,
                     std::vector<std::pair<size_t, size_t>>& result) const {
   assert(pattern_);
-  if (!pattern_)
+  if (!pattern_ || !pattern_->db())
     [[unlikely]] { return; }
 
   match(pattern_.get(), subject, result);
@@ -85,6 +85,8 @@ void Scanner::match(uint64_t id, std::string_view subject,
 void Scanner::match(const Pattern* pattern, std::string_view subject,
                     std::vector<std::pair<size_t, size_t>>& result) const {
   assert(pattern);
+  if (!pattern_ || !pattern_->db())
+    [[unlikely]] { return; }
 
   int rc = pcre2_jit_match(static_cast<const pcre2_code_8*>(pattern->db()),
                            reinterpret_cast<const unsigned char*>(subject.data()), subject.length(),
@@ -120,6 +122,8 @@ void Scanner::match(const Pattern* pattern, std::string_view subject,
 
 bool Scanner::match(const Pattern* pattern, std::string_view subject) const {
   assert(pattern);
+  if (!pattern_ || !pattern_->db())
+    [[unlikely]] { return false; }
 
   int rc = pcre2_jit_match(static_cast<const pcre2_code_8*>(pattern->db()),
                            reinterpret_cast<const unsigned char*>(subject.data()), subject.length(),
@@ -154,7 +158,7 @@ bool Scanner::match(std::string_view subject) const { return match(pattern_.get(
 void Scanner::matchGlobal(std::string_view subject,
                           std::vector<std::pair<size_t, size_t>>& result) const {
   assert(pattern_);
-  if (!pattern_)
+  if (!pattern_ || !pattern_->db())
     [[unlikely]] { return; }
 
   return matchGlobal(pattern_.get(), subject, result);
@@ -174,6 +178,9 @@ void Scanner::matchGlobal(uint64_t id, std::string_view subject,
 void Scanner::matchGlobal(const Pattern* pattern, std::string_view subject,
                           std::vector<std::pair<size_t, size_t>>& result) const {
   assert(pattern);
+  if (!pattern_ || !pattern_->db())
+    [[unlikely]] { return; }
+
   int rc = 0;
   size_t start_offset = 0;
   do {

--- a/src/common/re2/scanner.cc
+++ b/src/common/re2/scanner.cc
@@ -30,11 +30,13 @@ Scanner::Scanner(std::string_view pattern, bool case_less, bool captrue) {
   RE2::Options options;
   options.set_case_sensitive(!case_less);
   options.set_never_capture(!captrue);
+  options.set_log_errors(false);
   re2_ = std::make_unique<RE2>(pattern, options);
 }
 
 void Scanner::match(std::string_view subject,
                     std::vector<std::pair<size_t, size_t>>& result) const {
+  assert(re2_->ok());
   int groups = re2_->NumberOfCapturingGroups();
   std::vector<re2::StringPiece> submatch(groups + 1); // +1 for full match
 
@@ -50,7 +52,10 @@ void Scanner::match(std::string_view subject,
   }
 }
 
-bool Scanner::match(std::string_view subject) const { return RE2::PartialMatch(subject, *re2_); }
+bool Scanner::match(std::string_view subject) const {
+  assert(re2_->ok());
+  return RE2::PartialMatch(subject, *re2_);
+}
 } // namespace Re2
 } // namespace Common
 } // namespace Wge

--- a/src/common/re2/scanner.h
+++ b/src/common/re2/scanner.h
@@ -37,6 +37,7 @@ public:
 
 public:
   bool ok() const { return re2_ && re2_->ok(); }
+  const std::string& error() const { return re2_->error(); }
   void match(std::string_view subject, std::vector<std::pair<size_t, size_t>>& result) const;
   bool match(std::string_view subject) const;
 

--- a/src/operator/rx.h
+++ b/src/operator/rx.h
@@ -145,6 +145,8 @@ private:
       if (re2->ok()) {
         scanner = std::move(re2);
       } else {
+        WGE_LOG_WARN("Failed to compile RE2 pattern '{}': {}. Use PCRE instead.", pattern,
+                     re2->error());
         scanner = std::make_unique<Common::Pcre::Scanner>(pattern, false, capture_);
       }
     }

--- a/test/integration/02_rule_operator_test.cc
+++ b/test/integration/02_rule_operator_test.cc
@@ -276,6 +276,21 @@ TEST_F(RuleOperatorTest, rx) {
   EXPECT_FALSE(t->hasVariable("false"));
 }
 
+// Issue #77 - RX operator should handle invalid patterns gracefully
+TEST_F(RuleOperatorTest, rxWithInvalidPattern) {
+  const std::string directive =
+      R"(SecAction "phase:1,setvar:tx.foo=helloworld123helloworld"
+  SecRule TX:foo "@rx ***})([++++]++????" "id:1,phase:1,setvar:'tx.true1'")";
+
+  auto result = engine_.load(directive);
+  engine_.init();
+  auto t = engine_.makeTransaction();
+  ASSERT_TRUE(result.has_value());
+
+  t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
+  EXPECT_FALSE(t->hasVariable("true1"));
+}
+
 TEST_F(RuleOperatorTest, rxWithMacro) {
   const std::string directive =
       R"(SecAction "phase:1,setvar:tx.foo=helloworld123helloworld"


### PR DESCRIPTION
If an invalid regex pattern is provided to the rx operator, the system crashes due to dereferencing a null pointer. This commit returns false early in such cases to prevent crashes.

Fixes #77