### PR TITLE
fix(macro): fix memory corruption

### DIFF
--- a/src/macro/multi_macro.h
+++ b/src/macro/multi_macro.h
@@ -48,20 +48,26 @@ public:
         auto pos2 = eval.find('}', pos1);
         assert(pos2 != std::string::npos);
         macro->evaluate(t, result);
-        if (IS_INT_VARIANT(result.front().variant_)) {
-          eval = eval.replace(pos1, pos2 - pos1 + 1,
-                              std::to_string(std::get<int64_t>(result.front().variant_)));
-        } else if (IS_STRING_VIEW_VARIANT(result.front().variant_)) {
-          std::string_view sv = std::get<std::string_view>(result.front().variant_);
-          eval = eval.replace(pos1, pos2 - pos1 + 1, sv.data(), sv.size());
-        } else
-          [[unlikely]] {
-            // UNREACHABLE();
-            WGE_LOG_WARN(
-                "macro {} expanded: unexpected variant type {}, expected int64_t or string_view",
-                literal_value_, VISTIT_VARIANT_AS_STRING(result.front().variant_));
-            eval = eval.replace(pos1, pos2 - pos1 + 1, "");
-          }
+        if (!result.empty()) {
+          if (IS_INT_VARIANT(result.front().variant_)) {
+            eval = eval.replace(pos1, pos2 - pos1 + 1,
+                                std::to_string(std::get<int64_t>(result.front().variant_)));
+          } else if (IS_STRING_VIEW_VARIANT(result.front().variant_)) {
+            std::string_view sv = std::get<std::string_view>(result.front().variant_);
+            eval = eval.replace(pos1, pos2 - pos1 + 1, sv.data(), sv.size());
+          } else
+            [[unlikely]] {
+              // UNREACHABLE();
+              WGE_LOG_WARN(
+                  "macro {} expanded: unexpected variant type {}, expected int64_t or string_view",
+                  literal_value_, VISTIT_VARIANT_AS_STRING(result.front().variant_));
+              eval = eval.replace(pos1, pos2 - pos1 + 1, "");
+            }
+        } else {
+          WGE_LOG_WARN("macro {} expanded: empty result, expected int64_t or string_view",
+                       literal_value_);
+          eval = eval.replace(pos1, pos2 - pos1 + 1, "");
+        }
 
         // Clear the result for the next macro.
         result.clear();

--- a/src/macro/variable_macro.h
+++ b/src/macro/variable_macro.h
@@ -37,7 +37,7 @@ public:
   void evaluate(Transaction& t, Common::EvaluateResults& result) const override {
     variable_->evaluate(t, result);
     WGE_LOG_TRACE("macro %{{{}}} expanded: {}", makeVariableName(),
-                  VISTIT_VARIANT_AS_STRING(result.front().variant_));
+                  result.empty() ? "nil" : VISTIT_VARIANT_AS_STRING(result.front().variant_));
   }
 
 public:

--- a/src/rule.cc
+++ b/src/rule.cc
@@ -454,7 +454,7 @@ bool Rule::evaluateWithMultiMatch(Transaction& t) const {
     const Common::EvaluateElement* evaluated_value = nullptr;
     for (size_t i = 0; i < result.size();) {
       if (evaluated_value == nullptr) {
-        evaluated_value = &result.at(i);
+        evaluated_value = &result[i];
       }
 
       // Evaluate the operator
@@ -473,7 +473,7 @@ bool Rule::evaluateWithMultiMatch(Transaction& t) const {
         }());
 
         if (isNeedPushMatched()) {
-          t.pushMatchedVariable(var.get(), chain_index_, result.at(i), transformed_value,
+          t.pushMatchedVariable(var.get(), chain_index_, result[i], transformed_value,
                                 captured_value, std::move(transform_list));
         }
 


### PR DESCRIPTION
Fix memory corruption when accessing Common::EvaluateResults