### PR TITLE
fix(antlr4): fix debug scripts

### DIFF
--- a/src/antlr4/CMakeLists.txt
+++ b/src/antlr4/CMakeLists.txt
@@ -23,9 +23,13 @@ add_custom_command(
 
 find_package(antlr4-runtime CONFIG REQUIRED)
 
+add_subdirectory(debug)
+
 add_library(antlr4 ${local_source} ${generated_source})
 target_include_directories(antlr4 PRIVATE ${CMAKE_BINARY_DIR}/src/antlr4)
 target_link_libraries(antlr4 PRIVATE antlr4_static)
+add_dependencies(antlr4_debug_lexer antlr4)
+add_dependencies(antlr4_debug_parser antlr4)
 
 find_package(spdlog CONFIG REQUIRED)
 target_link_libraries(antlr4 PRIVATE spdlog::spdlog_header_only)

--- a/src/antlr4/debug/CMakeLists.txt
+++ b/src/antlr4/debug/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+find_package(antlr4-runtime CONFIG REQUIRED)
+
+add_executable(antlr4_debug_lexer debug_lexer.cc ${CMAKE_BINARY_DIR}/src/antlr4/antlr4_gen/SecLangLexer.cpp)
+add_executable(antlr4_debug_parser debug_parser.cc ${CMAKE_BINARY_DIR}/src/antlr4/antlr4_gen/SecLangLexer.cpp ${CMAKE_BINARY_DIR}/src/antlr4/antlr4_gen/SecLangParser.cpp)
+
+target_include_directories(antlr4_debug_lexer PRIVATE ${CMAKE_BINARY_DIR}/src/antlr4)
+target_include_directories(antlr4_debug_parser PRIVATE ${CMAKE_BINARY_DIR}/src/antlr4)
+target_link_libraries(antlr4_debug_lexer PRIVATE antlr4_static)
+target_link_libraries(antlr4_debug_parser PRIVATE antlr4_static)

--- a/src/antlr4/debug/debug_lexer.cc
+++ b/src/antlr4/debug/debug_lexer.cc
@@ -1,0 +1,34 @@
+#include <fstream>
+#include <iostream>
+
+#include "antlr4-runtime.h"
+#include "antlr4_gen/SecLangLexer.h"
+
+int main(int argc, char* argv[]) {
+  using namespace antlr4;
+  using namespace Wge::Antlr4::Antlr4Gen;
+
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <input_file>" << std::endl;
+    return 1;
+  }
+
+  std::ifstream stream;
+  stream.open(argv[1]);
+  if (!stream.is_open()) {
+    std::cerr << "Error: Could not open file " << argv[1] << std::endl;
+    return 1;
+  }
+
+  ANTLRInputStream input(stream);
+  SecLangLexer lexer(&input);
+  CommonTokenStream tokens(&lexer);
+
+  tokens.fill();
+
+  for (auto token : tokens.getTokens()) {
+    std::cout << token->toString() << std::endl;
+  }
+
+  return 0;
+}

--- a/src/antlr4/debug/debug_lexer.sh
+++ b/src/antlr4/debug/debug_lexer.sh
@@ -2,22 +2,17 @@
 set -e
 
 DIR=$(dirname "$0")
-OUTPUT=debug/output
+PROJECT_ROOT=${DIR}/../../..
 
-function antlr4() {
-  java -Xmx500M -cp "/usr/local/lib/antlr-4.13.2-complete.jar:$CLASSPATH" org.antlr.v4.Tool "$@"
-}
+# Change to project root directory
+cd ${PROJECT_ROOT}
+BUILD_DIR=$(pwd)/build/debug
+INPUT_FILE=$(pwd)/src/antlr4/debug/input.txt
 
-cd ${DIR}/../
+# Build the antlr4_debug_lexer target using cmake
+echo "Building antlr4_debug_lexer target..."
+cmake --build "${BUILD_DIR}" --target antlr4_debug_lexer
 
-# Generate lexer files
-antlr4 -Dlanguage=Java -o ${OUTPUT} SecLangLexer.g4
-
-# Compile the generated lexer files
-javac -cp "/usr/local/lib/antlr-4.13.2-complete.jar" ${OUTPUT}/*.java
-
-# Run the lexer on the input file
-java -cp "/usr/local/lib/antlr-4.13.2-complete.jar:${OUTPUT}" org.antlr.v4.gui.TestRig SecLangLexer tokens -tokens debug/input.txt
-
-# Clean up generated files
-rm -rf ${OUTPUT}
+# Run the debug lexer with the input file
+echo "Running antlr4_debug_lexer with input file: ${INPUT_FILE}"
+${BUILD_DIR}/src/antlr4/debug/antlr4_debug_lexer ${INPUT_FILE}

--- a/src/antlr4/debug/debug_parser.cc
+++ b/src/antlr4/debug/debug_parser.cc
@@ -1,0 +1,36 @@
+#include <fstream>
+#include <iostream>
+
+#include "antlr4-runtime.h"
+#include "antlr4_gen/SecLangLexer.h"
+#include "antlr4_gen/SecLangParser.h"
+
+int main(int argc, char* argv[]) {
+  using namespace antlr4;
+  using namespace Wge::Antlr4::Antlr4Gen;
+
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <input_file>" << std::endl;
+    return 1;
+  }
+
+  std::ifstream stream;
+  stream.open(argv[1]);
+  if (!stream.is_open()) {
+    std::cerr << "Error: Could not open file " << argv[1] << std::endl;
+    return 1;
+  }
+
+  ANTLRInputStream input(stream);
+  SecLangLexer lexer(&input);
+  CommonTokenStream tokens(&lexer);
+  SecLangParser parser(&tokens);
+
+  // Parse the configuration
+  auto tree = parser.configuration();
+
+  // Print the parse tree
+  std::cout << tree->toStringTree(&parser) << std::endl;
+
+  return 0;
+}

--- a/src/antlr4/debug/debug_parser.sh
+++ b/src/antlr4/debug/debug_parser.sh
@@ -2,23 +2,17 @@
 set -e
 
 DIR=$(dirname "$0")
-OUTPUT=debug/output
+PROJECT_ROOT=${DIR}/../../..
 
-function antlr4() {
-  java -Xmx500M -cp "/usr/local/lib/antlr-4.13.2-complete.jar:$CLASSPATH" org.antlr.v4.Tool "$@"
-}
+# Change to project root directory
+cd ${PROJECT_ROOT}
+BUILD_DIR=$(pwd)/build/debug
+INPUT_FILE=$(pwd)/src/antlr4/debug/input.txt
 
-cd ${DIR}/../
+# Build the antlr4_debug_lexer target using cmake
+echo "Building antlr4_debug_lexer target..."
+cmake --build "${BUILD_DIR}" --target antlr4_debug_parser
 
-# Generate lexer and parser files
-antlr4 -Dlanguage=Java -o ${OUTPUT} SecLangLexer.g4 SecLangParser.g4
-
-# Compile the generated lexer and parser files
-javac -cp "/usr/local/lib/antlr-4.13.2-complete.jar" ${OUTPUT}/*.java
-
-# Run the configuration rule on the input file, and print the parse tree
-# java -cp "/usr/local/lib/antlr-4.13.2-complete.jar:${OUTPUT}" org.antlr.v4.gui.TestRig SecLang configuration -tokens debug/input.txt
-java -cp "/usr/local/lib/antlr-4.13.2-complete.jar:${OUTPUT}" org.antlr.v4.gui.TestRig SecLang configuration -tree debug/input.txt
-
-# Clean up generated files
-rm -rf ${OUTPUT}
+# Run the debug lexer with the input file
+echo "Running antlr4_debug_parser with input file: ${INPUT_FILE}"
+${BUILD_DIR}/src/antlr4/debug/antlr4_debug_parser ${INPUT_FILE}


### PR DESCRIPTION
The old scripts used java to compile and run the lexer/parser, but lexer/parser uses c++ lambda features that are not supported by java target. Updated the scripts to use cmake build system to compile and run the debug lexer/parser.