### PR TITLE
feat: add firstMatch and emptyMatch flags

### DIFF
--- a/src/antlr4/SecLangLexer.g4
+++ b/src/antlr4/SecLangLexer.g4
@@ -612,6 +612,9 @@ T: 't' -> pushMode(ModeSecRuleActionT);
 Tag: 'tag';
 Ver: 'ver';
 Xmlns: 'xmlns' -> pushMode(ModeSecRuleActionRedirect);
+// Extensions:
+FirstMatch: 'firstMatch';
+EmptyMatch: 'emptyMatch';
 
 mode ModeSecRuleActionSetVar;
 ModeSecRuleActionSetVar_WS: WS -> skip;

--- a/src/antlr4/SecLangParser.g4
+++ b/src/antlr4/SecLangParser.g4
@@ -1029,7 +1029,8 @@ action:
 	| action_non_disruptive
 	| action_disruptive
 	| action_data
-	| action_flow;
+	| action_flow
+	| action_extension;
 
 action_meta_data:
 	action_meta_data_id
@@ -1373,6 +1374,10 @@ action_flow:
 action_flow_chain: Chain;
 action_flow_skip: Skip COLON INT;
 action_flow_skip_after: SkipAfter COLON STRING;
+
+action_extension: action_extension_first_match | action_extension_empty_match;
+action_extension_first_match: FirstMatch;
+action_extension_empty_match: EmptyMatch;
 
 audit_log_config:
 	sec_audit_engine

--- a/src/antlr4/visitor.cc
+++ b/src/antlr4/visitor.cc
@@ -2291,6 +2291,18 @@ Visitor::visitAction_flow_skip_after(Antlr4Gen::SecLangParser::Action_flow_skip_
   return EMPTY_STRING;
 }
 
+std::any Visitor::visitAction_extension_first_match(
+    Antlr4Gen::SecLangParser::Action_extension_first_matchContext* ctx) {
+  current_rule_->get()->firstMatch(true);
+  return EMPTY_STRING;
+}
+
+std::any Visitor::visitAction_extension_empty_match(
+    Antlr4Gen::SecLangParser::Action_extension_empty_matchContext* ctx) {
+  current_rule_->get()->emptyMatch(true);
+  return EMPTY_STRING;
+}
+
 std::any Visitor::visitSec_audit_engine(Antlr4Gen::SecLangParser::Sec_audit_engineContext* ctx) {
   using Option = Wge::AuditLogConfig::AuditEngine;
   Option option = Option::Off;

--- a/src/antlr4/visitor.h
+++ b/src/antlr4/visitor.h
@@ -804,6 +804,14 @@ public:
   std::any visitAction_flow_skip_after(
       Antlr4Gen::SecLangParser::Action_flow_skip_afterContext* ctx) override;
 
+  // Extension actions
+public:
+  std::any visitAction_extension_first_match(
+      Antlr4Gen::SecLangParser::Action_extension_first_matchContext* ctx) override;
+
+  std::any visitAction_extension_empty_match(
+      Antlr4Gen::SecLangParser::Action_extension_empty_matchContext* ctx) override;
+
   // Audit log configurations
 public:
   std::any visitSec_audit_engine(Antlr4Gen::SecLangParser::Sec_audit_engineContext* ctx) override;

--- a/src/operator/begins_with.h
+++ b/src/operator/begins_with.h
@@ -47,7 +47,11 @@ public:
           [[likely]] { return std::get<std::string_view>(operand).starts_with(literal_value_); }
         else {
           MACRO_EXPAND_STRING_VIEW(macro_value);
-          return std::get<std::string_view>(operand).starts_with(macro_value);
+          if (!macro_value) {
+            return empty_match_;
+          }
+
+          return std::get<std::string_view>(operand).starts_with(*macro_value);
         }
       }
     else {

--- a/src/operator/contains.h
+++ b/src/operator/contains.h
@@ -50,9 +50,14 @@ public:
           }
         else {
           MACRO_EXPAND_STRING_VIEW(macro_value);
-          matched = std::get<std::string_view>(operand).find(macro_value) != std::string_view::npos;
+          if (!macro_value) {
+            return empty_match_;
+          }
+
+          matched =
+              std::get<std::string_view>(operand).find(*macro_value) != std::string_view::npos;
           if (matched) {
-            t.stageCapture(0, macro_value);
+            t.stageCapture(0, *macro_value);
           }
         }
       }

--- a/src/operator/ends_with.h
+++ b/src/operator/ends_with.h
@@ -43,7 +43,11 @@ public:
           [[likely]] { return std::get<std::string_view>(operand).ends_with(literal_value_); }
         else {
           MACRO_EXPAND_STRING_VIEW(macro_value);
-          return std::get<std::string_view>(operand).ends_with(macro_value);
+          if (!macro_value) {
+            return empty_match_;
+          }
+
+          return std::get<std::string_view>(operand).ends_with(*macro_value);
         }
       }
     else {

--- a/src/operator/eq.h
+++ b/src/operator/eq.h
@@ -51,7 +51,11 @@ public:
       [[likely]] { return operand_value == value_; }
     else {
       MACRO_EXPAND_INT(macro_value);
-      return operand_value == macro_value;
+      if (!macro_value) {
+        return empty_match_;
+      }
+
+      return operand_value == *macro_value;
     }
   }
 

--- a/src/operator/ge.h
+++ b/src/operator/ge.h
@@ -46,7 +46,11 @@ public:
       [[likely]] { return operand_value >= value_; }
     else {
       MACRO_EXPAND_INT(macro_value);
-      return operand_value >= macro_value;
+      if (!macro_value) {
+        return empty_match_;
+      }
+
+      return operand_value >= *macro_value;
     }
   }
 

--- a/src/operator/gt.h
+++ b/src/operator/gt.h
@@ -46,7 +46,11 @@ public:
       [[likely]] { return operand_value > value_; }
     else {
       MACRO_EXPAND_INT(macro_value);
-      return operand_value > macro_value;
+      if (!macro_value) {
+        return empty_match_;
+      }
+
+      return operand_value > *macro_value;
     }
   }
 

--- a/src/operator/le.h
+++ b/src/operator/le.h
@@ -46,7 +46,11 @@ public:
       [[likely]] { return operand_value <= value_; }
     else {
       MACRO_EXPAND_INT(macro_value);
-      return operand_value <= macro_value;
+      if (!macro_value) {
+        return empty_match_;
+      }
+
+      return operand_value <= *macro_value;
     }
   }
 

--- a/src/operator/lt.h
+++ b/src/operator/lt.h
@@ -46,7 +46,11 @@ public:
       [[likely]] { return operand_value < value_; }
     else {
       MACRO_EXPAND_INT(macro_value);
-      return operand_value < macro_value;
+      if (!macro_value) {
+        return empty_match_;
+      }
+
+      return operand_value < *macro_value;
     }
   }
 

--- a/src/operator/streq.h
+++ b/src/operator/streq.h
@@ -47,7 +47,11 @@ public:
           [[likely]] { return literal_value_ == std::get<std::string_view>(operand); }
         else {
           MACRO_EXPAND_STRING_VIEW(macro_value);
-          return macro_value == std::get<std::string_view>(operand);
+          if (!macro_value) {
+            return empty_match_;
+          }
+
+          return *macro_value == std::get<std::string_view>(operand);
         }
       }
     else {

--- a/src/operator/within.h
+++ b/src/operator/within.h
@@ -76,9 +76,12 @@ public:
     if (macro_)
       [[unlikely]] {
         MACRO_EXPAND_STRING_VIEW(macro_value);
+        if (!macro_value) {
+          return empty_match_;
+        }
 
         // Split the literal value into tokens.
-        std::vector<std::string_view> tokens = Common::SplitTokens(macro_value);
+        std::vector<std::string_view> tokens = Common::SplitTokens(*macro_value);
 
         // Calculate the order independent hash value of all tokens.
         int64_t hash = calcOrderIndependentHash(tokens);

--- a/src/rule.cc
+++ b/src/rule.cc
@@ -208,6 +208,13 @@ bool Rule::evaluate(Transaction& t) const {
 
         // Evaluate the default actions and the action defined actions
         evaluateActions(t);
+
+        // If the first match is enabled, stop evaluating the rule
+        if (firstMatch())
+          [[unlikely]] {
+            WGE_LOG_TRACE("first match is enabled, stop evaluating the rule");
+            break;
+          }
       }
     }
   }
@@ -250,6 +257,14 @@ void Rule::capture(bool value) {
     rx->capture(value);
   }
   flags_.set(static_cast<size_t>(Flags::CAPTURE), value);
+}
+
+void Rule::emptyMatch(bool value) {
+  if (operator_) {
+    operator_->emptyMatch(value);
+  }
+
+  flags_.set(static_cast<size_t>(Flags::EMPTY_MATCH), value);
 }
 
 void Rule::setOperator(std::unique_ptr<Operator::OperatorBase>&& op) {
@@ -481,6 +496,13 @@ bool Rule::evaluateWithMultiMatch(Transaction& t) const {
 
         // Evaluate the default actions and the action defined actions
         evaluateActions(t);
+
+        // If the first match is enabled, stop evaluating the rule
+        if (firstMatch())
+          [[unlikely]] {
+            WGE_LOG_TRACE("first match is enabled, stop evaluating the rule");
+            break;
+          }
 
         // The variable value is matched, evaluate next variable value
         i++;

--- a/test/parser/rule_action_parse_test.cc
+++ b/test/parser/rule_action_parse_test.cc
@@ -787,5 +787,24 @@ TEST_F(RuleActionParseTest, ActionLogDataWithMacro) {
 
   EXPECT_TRUE(parser.rules()[0].back().logdata().empty());
 }
+
+TEST_F(RuleActionParseTest, ActionFirstMatch) {
+  const std::string rule_directive = R"(SecRule ARGS "foo" "id:1,phase:1,firstMatch,msg:'aaa'")";
+  Antlr4::Parser parser;
+  auto result = parser.load(rule_directive);
+  ASSERT_TRUE(result.has_value());
+
+  EXPECT_TRUE(parser.rules()[0].back().firstMatch());
+}
+
+TEST_F(RuleActionParseTest, ActionEmptyMatch) {
+  const std::string rule_directive =
+      R"(SecRule ARGS "@rx %{tx.foo}" "id:1,phase:1,emptyMatch,msg:'aaa'")";
+  Antlr4::Parser parser;
+  auto result = parser.load(rule_directive);
+  ASSERT_TRUE(result.has_value());
+
+  EXPECT_TRUE(parser.rules()[0].back().emptyMatch());
+}
 } // namespace Parser
 } // namespace Wge


### PR DESCRIPTION
- Added `firstMatch` flag to rules to stop evaluation after the first successful match.
- Added `emptyMatch` flag to operators to allow match on empty macro values.