### PR TITLE
feat: support set tx namespace and gtx variable

### DIFF
--- a/src/action/set_var.h
+++ b/src/action/set_var.h
@@ -49,12 +49,14 @@ public:
   enum class EvaluateType { Create, CreateAndInit, Remove, Increase, Decrease };
 
 public:
-  SetVar(std::string&& key, size_t index, Common::Variant&& value, EvaluateType type);
-  SetVar(std::string&& key, size_t index, std::unique_ptr<Macro::MacroBase>&& value,
+  SetVar(const std::string& ns, std::string&& key, size_t index, Common::Variant&& value,
          EvaluateType type);
-  SetVar(std::unique_ptr<Macro::MacroBase>&& key, Common::Variant&& value, EvaluateType type);
-  SetVar(std::unique_ptr<Macro::MacroBase>&& key, std::unique_ptr<Macro::MacroBase>&& value,
+  SetVar(const std::string& ns, std::string&& key, size_t index,
+         std::unique_ptr<Macro::MacroBase>&& value, EvaluateType type);
+  SetVar(const std::string& ns, std::unique_ptr<Macro::MacroBase>&& key, Common::Variant&& value,
          EvaluateType type);
+  SetVar(const std::string& ns, std::unique_ptr<Macro::MacroBase>&& key,
+         std::unique_ptr<Macro::MacroBase>&& value, EvaluateType type);
 
 public:
   void evaluate(Transaction& t) const override;
@@ -65,6 +67,7 @@ public:
   size_t index() const { return index_; }
 
 private:
+  std::string namespace_;
   std::string key_;
   size_t index_;
   const Common::Variant value_;

--- a/src/antlr4/SecLangLexer.g4
+++ b/src/antlr4/SecLangLexer.g4
@@ -153,6 +153,8 @@ SecRuleUpdateOperatorById:
 	'SecRuleUpdateOperatorById' -> pushMode(ModeRuleUpdateOperatorById);
 SecRuleUpdateOperatorByTag:
 	'SecRuleUpdateOperatorByTag' -> pushMode(ModeRuleUpdateOperatorByTag);
+SecTxNamespace:
+	'SecTxNamespace' -> pushMode(ModeAuditLogString);
 
 mode ModeInclude;
 ModeInclude_WS: WS -> skip;
@@ -452,6 +454,7 @@ VAR_IP: [iI][pP];
 VAR_USER: [uU][sS][eE][rR];
 VAR_PTREE:
 	[pP][tT][rR][eE][eE] -> pushMode(ModeSecRuleVariableNamePtree);
+VAR_GTX: [gG][tT][xX];
 ModeSecRuleVariableName_WS: WS -> skip, popMode;
 ModeSecRuleVariableName_COMMA: COMMA -> skip, popMode;
 ModeSecRuleVariableName_PIPE: PIPE -> type(PIPE);
@@ -496,7 +499,8 @@ ModeSecRuleVariableNamePtree_LEFT_SQUARE:
 	LEFT_SQUARE -> type(LEFT_SQUARE);
 ModeSecRuleVariableNamePtree_RIGHT_SQUARE:
 	RIGHT_SQUARE -> type(RIGHT_SQUARE);
-ModeSecRuleVariableNamePtree_PIPE: PIPE -> type(PIPE), popMode;
+ModeSecRuleVariableNamePtree_PIPE:
+	PIPE -> type(PIPE), popMode;
 
 mode ModeSecRuleVariableSubNamePtree;
 ModeSecRuleVariableSubNamePtree_VAR_SUB_NAME:

--- a/src/antlr4/SecLangParser.g4
+++ b/src/antlr4/SecLangParser.g4
@@ -943,7 +943,7 @@ variable_user:
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
 		)
 	)?;
-extension_variable: variable_ptree;
+extension_variable: variable_ptree | variable_gtx;
 variable_ptree:
 	NOT? VAR_COUNT? VAR_PTREE (COLON | DOT) variable_ptree_expression;
 variable_ptree_expression:
@@ -953,6 +953,13 @@ variable_ptree_expression:
 			| (LEFT_BRACKET AND? RIGHT_BRACKET)
 		)?
 	)+;
+variable_gtx:
+	NOT? VAR_COUNT? VAR_GTX (
+		(COLON | DOT) (
+			STRING
+			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+		)
+	)?;
 
 operator:
 	op_begins_with
@@ -1386,7 +1393,9 @@ action_flow_chain: Chain;
 action_flow_skip: Skip COLON INT;
 action_flow_skip_after: SkipAfter COLON STRING;
 
-action_extension: action_extension_first_match | action_extension_empty_match;
+action_extension:
+	action_extension_first_match
+	| action_extension_empty_match;
 action_extension_first_match: FirstMatch;
 action_extension_empty_match: EmptyMatch;
 
@@ -1419,7 +1428,8 @@ sec_component_signature:
 
 extension_directive:
 	sec_rule_update_operator_by_id
-	| sec_rule_update_operator_by_tag;
+	| sec_rule_update_operator_by_tag
+	| sec_tx_namespace;
 sec_rule_update_operator_by_id:
 	SecRuleUpdateOperatorById (
 		INT
@@ -1428,3 +1438,4 @@ sec_rule_update_operator_by_id:
 	) (INT | INT_RANGE | ID_AND_CHAIN_INDEX)* QUOTE operator QUOTE;
 sec_rule_update_operator_by_tag:
 	SecRuleUpdateOperatorByTag QUOTE STRING QUOTE QUOTE operator QUOTE;
+sec_tx_namespace: SecTxNamespace STRING;

--- a/src/antlr4/parser.h
+++ b/src/antlr4/parser.h
@@ -142,9 +142,14 @@ public:
     return curr_load_file_.empty() ? "" : curr_load_file_.top();
   }
 
-  size_t getTxVariableIndexSize() const { return tx_variable_index_.size(); }
-  std::optional<size_t> getTxVariableIndex(const std::string& name, bool force);
-  std::string_view getTxVariableIndexReverse(size_t index) const;
+  const std::unordered_map<std::string, size_t>& getTxVariableIndexSize() const {
+    return tx_variable_index_size_;
+  }
+  std::optional<size_t> getTxVariableIndex(const std::string& ns, const std::string& name,
+                                           bool force);
+  std::string_view getTxVariableIndexReverse(const std::string& ns, size_t index) const;
+  void setCurrentNamespace(const std::string& ns) { curr_namespace_ = ns; }
+  const std::string& getCurrentNamespace() const { return curr_namespace_; }
 
 private:
   std::array<std::vector<Rule>, PHASE_TOTAL> rules_;
@@ -160,8 +165,12 @@ private:
   std::set<std::string> loaded_file_paths_;
   std::stack<std::string_view> curr_load_file_;
 
-  // Used to store the tx variable index of the vector tx_vec_.
-  std::unordered_map<std::string, size_t> tx_variable_index_;
-  std::vector<std::string> tx_variable_index_reverse_;
+  struct TxVariableIndex {
+    std::unordered_map<std::string, size_t> index_;
+    std::vector<std::string> index_reverse_;
+  };
+  std::unordered_map<std::string /*namespace*/, TxVariableIndex> tx_variable_index_;
+  std::unordered_map<std::string /*namespace*/, size_t> tx_variable_index_size_;
+  std::string curr_namespace_;
 };
 } // namespace Wge::Antlr4

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -102,7 +102,7 @@ const std::vector<Rule>& Engine::rules(RulePhaseType phase) const {
 
 TransactionPtr Engine::makeTransaction() const {
   assert(is_init_);
-  return std::unique_ptr<Transaction>(new Transaction(*this, parser_->getTxVariableIndexSize()));
+  return std::unique_ptr<Transaction>(new Transaction(*this));
 }
 
 const EngineConfig& Engine::config() const { return parser_->engineConfig(); }
@@ -143,12 +143,17 @@ void Engine::findRuleByTag(
   }
 }
 
-std::optional<size_t> Engine::getTxVariableIndex(const std::string& name) const {
-  return parser_->getTxVariableIndex(name, false);
+const std::unordered_map<std::string, size_t>& Engine::getTxVariableIndexSize() const {
+  return parser_->getTxVariableIndexSize();
 }
 
-std::string_view Engine::getTxVariableIndexReverse(size_t index) const {
-  return parser_->getTxVariableIndexReverse(index);
+std::optional<size_t> Engine::getTxVariableIndex(const std::string& ns,
+                                                 const std::string& name) const {
+  return parser_->getTxVariableIndex(ns, name, false);
+}
+
+std::string_view Engine::getTxVariableIndexReverse(const std::string& ns, size_t index) const {
+  return parser_->getTxVariableIndexReverse(ns, index);
 }
 
 void Engine::initRules() {

--- a/src/engine.h
+++ b/src/engine.h
@@ -151,19 +151,28 @@ public:
                      std::array<std::unordered_set<const Rule*>, PHASE_TOTAL>& rule_set) const;
 
   /**
+   * Get all namespaces and their variable index sizes
+   * @return map of namespace and variable index size. The key is the namespace, and the value is
+   * the size of the variable index.
+   */
+  const std::unordered_map<std::string, size_t>& getTxVariableIndexSize() const;
+
+  /**
    * Get the transaction variable index
+   * @param ns the variable namespace
    * @param name the variable name
    * @param force if true, insert a new index if the variable is not found
    * @return the index of the variable if found, and std::nullopt otherwise
    */
-  std::optional<size_t> getTxVariableIndex(const std::string& name) const;
+  std::optional<size_t> getTxVariableIndex(const std::string& ns, const std::string& name) const;
 
   /**
    * Get the transaction variable index reverse
+   * @param ns the variable namespace
    * @param index the index of the variable
    * @return the variable name. if the index is out of range, an empty string is returned
    */
-  std::string_view getTxVariableIndexReverse(size_t index) const;
+  std::string_view getTxVariableIndexReverse(const std::string& ns, size_t index) const;
 
   // std::optional<const std::vector<const Rule*>::iterator> marker(std::string_view name,
   //                                                                int phase) const;

--- a/test/integration/02_rule_operator_test.cc
+++ b/test/integration/02_rule_operator_test.cc
@@ -62,7 +62,7 @@ TEST_F(RuleOperatorTest, additionalCondition) {
     t->processRequestHeaders(nullptr, nullptr, 0, nullptr, nullptr,
                              [](const Rule& rule, const Variable::VariableBase& variable,
                                 std::string_view value, void* user_data) { return true; });
-    EXPECT_TRUE(t->hasVariable("v1"));
+    EXPECT_TRUE(t->hasVariable("", "v1"));
   }
 
   {
@@ -72,7 +72,7 @@ TEST_F(RuleOperatorTest, additionalCondition) {
     t->processRequestHeaders(nullptr, nullptr, 0, nullptr, nullptr,
                              [](const Rule& rule, const Variable::VariableBase& variable,
                                 std::string_view value, void* user_data) { return false; });
-    EXPECT_FALSE(t->hasVariable("v1"));
+    EXPECT_FALSE(t->hasVariable("", "v1"));
   }
 }
 
@@ -88,8 +88,8 @@ TEST_F(RuleOperatorTest, beginsWith) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("v1"));
-  EXPECT_FALSE(t->hasVariable("v2"));
+  EXPECT_TRUE(t->hasVariable("", "v1"));
+  EXPECT_FALSE(t->hasVariable("", "v2"));
 }
 
 TEST_F(RuleOperatorTest, beginsWithMacro) {
@@ -104,8 +104,8 @@ TEST_F(RuleOperatorTest, beginsWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("v1"));
-  EXPECT_FALSE(t->hasVariable("v2"));
+  EXPECT_TRUE(t->hasVariable("", "v1"));
+  EXPECT_FALSE(t->hasVariable("", "v2"));
 }
 
 TEST_F(RuleOperatorTest, endsWith) {
@@ -120,8 +120,8 @@ TEST_F(RuleOperatorTest, endsWith) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("v1"));
-  EXPECT_FALSE(t->hasVariable("v2"));
+  EXPECT_TRUE(t->hasVariable("", "v1"));
+  EXPECT_FALSE(t->hasVariable("", "v2"));
 }
 
 TEST_F(RuleOperatorTest, endsWithMacro) {
@@ -136,8 +136,8 @@ TEST_F(RuleOperatorTest, endsWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("v1"));
-  EXPECT_FALSE(t->hasVariable("v2"));
+  EXPECT_TRUE(t->hasVariable("", "v1"));
+  EXPECT_FALSE(t->hasVariable("", "v2"));
 }
 
 TEST_F(RuleOperatorTest, detect_sqli) {
@@ -151,7 +151,7 @@ TEST_F(RuleOperatorTest, detect_sqli) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("v1"));
+  EXPECT_TRUE(t->hasVariable("", "v1"));
 }
 
 TEST_F(RuleOperatorTest, ipMatch) {
@@ -173,14 +173,14 @@ TEST_F(RuleOperatorTest, ipMatch) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("ipv4_true"));
-  EXPECT_FALSE(t->hasVariable("ipv4_false"));
-  EXPECT_TRUE(t->hasVariable("ipv4_mark_true"));
-  EXPECT_FALSE(t->hasVariable("ipv4_mark_false"));
-  EXPECT_TRUE(t->hasVariable("ipv6_true"));
-  EXPECT_FALSE(t->hasVariable("ipv6_false"));
-  EXPECT_TRUE(t->hasVariable("ipv6_mask_true"));
-  EXPECT_FALSE(t->hasVariable("ipv6_mask_false"));
+  EXPECT_TRUE(t->hasVariable("", "ipv4_true"));
+  EXPECT_FALSE(t->hasVariable("", "ipv4_false"));
+  EXPECT_TRUE(t->hasVariable("", "ipv4_mark_true"));
+  EXPECT_FALSE(t->hasVariable("", "ipv4_mark_false"));
+  EXPECT_TRUE(t->hasVariable("", "ipv6_true"));
+  EXPECT_FALSE(t->hasVariable("", "ipv6_false"));
+  EXPECT_TRUE(t->hasVariable("", "ipv6_mask_true"));
+  EXPECT_FALSE(t->hasVariable("", "ipv6_mask_false"));
 }
 
 TEST_F(RuleOperatorTest, pm) {
@@ -198,11 +198,11 @@ TEST_F(RuleOperatorTest, pm) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true1"));
-  EXPECT_TRUE(t->hasVariable("true2"));
-  EXPECT_TRUE(t->hasVariable("true3"));
-  EXPECT_FALSE(t->hasVariable("false1"));
-  EXPECT_FALSE(t->hasVariable("false2"));
+  EXPECT_TRUE(t->hasVariable("", "true1"));
+  EXPECT_TRUE(t->hasVariable("", "true2"));
+  EXPECT_TRUE(t->hasVariable("", "true3"));
+  EXPECT_FALSE(t->hasVariable("", "false1"));
+  EXPECT_FALSE(t->hasVariable("", "false2"));
 }
 
 TEST_F(RuleOperatorTest, within) {
@@ -220,11 +220,11 @@ TEST_F(RuleOperatorTest, within) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true1"));
-  EXPECT_TRUE(t->hasVariable("true2"));
-  EXPECT_TRUE(t->hasVariable("true3"));
-  EXPECT_FALSE(t->hasVariable("false1"));
-  EXPECT_FALSE(t->hasVariable("false2"));
+  EXPECT_TRUE(t->hasVariable("", "true1"));
+  EXPECT_TRUE(t->hasVariable("", "true2"));
+  EXPECT_TRUE(t->hasVariable("", "true3"));
+  EXPECT_FALSE(t->hasVariable("", "false1"));
+  EXPECT_FALSE(t->hasVariable("", "false2"));
 }
 
 TEST_F(RuleOperatorTest, withinWithMacro) {
@@ -248,12 +248,12 @@ TEST_F(RuleOperatorTest, withinWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true1"));
-  EXPECT_TRUE(t->hasVariable("true2"));
-  EXPECT_TRUE(t->hasVariable("true3"));
-  EXPECT_TRUE(t->hasVariable("true4"));
-  EXPECT_FALSE(t->hasVariable("false1"));
-  EXPECT_FALSE(t->hasVariable("false2"));
+  EXPECT_TRUE(t->hasVariable("", "true1"));
+  EXPECT_TRUE(t->hasVariable("", "true2"));
+  EXPECT_TRUE(t->hasVariable("", "true3"));
+  EXPECT_TRUE(t->hasVariable("", "true4"));
+  EXPECT_FALSE(t->hasVariable("", "false1"));
+  EXPECT_FALSE(t->hasVariable("", "false2"));
 }
 
 TEST_F(RuleOperatorTest, rx) {
@@ -269,9 +269,9 @@ TEST_F(RuleOperatorTest, rx) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true1"));
-  EXPECT_TRUE(t->hasVariable("true2"));
-  EXPECT_FALSE(t->hasVariable("false"));
+  EXPECT_TRUE(t->hasVariable("", "true1"));
+  EXPECT_TRUE(t->hasVariable("", "true2"));
+  EXPECT_FALSE(t->hasVariable("", "false"));
 }
 
 // Issue #77 - RX operator should handle invalid patterns gracefully
@@ -286,7 +286,7 @@ TEST_F(RuleOperatorTest, rxWithInvalidPattern) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_FALSE(t->hasVariable("true1"));
+  EXPECT_FALSE(t->hasVariable("", "true1"));
 }
 
 TEST_F(RuleOperatorTest, rxWithMacro) {
@@ -306,10 +306,10 @@ TEST_F(RuleOperatorTest, rxWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true1"));
-  EXPECT_TRUE(t->hasVariable("true2"));
-  EXPECT_TRUE(t->hasVariable("true3"));
-  EXPECT_FALSE(t->hasVariable("false"));
+  EXPECT_TRUE(t->hasVariable("", "true1"));
+  EXPECT_TRUE(t->hasVariable("", "true2"));
+  EXPECT_TRUE(t->hasVariable("", "true3"));
+  EXPECT_FALSE(t->hasVariable("", "false"));
 }
 
 TEST_F(RuleOperatorTest, pmFromFile) {
@@ -324,8 +324,8 @@ TEST_F(RuleOperatorTest, pmFromFile) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true"));
-  EXPECT_FALSE(t->hasVariable("false"));
+  EXPECT_TRUE(t->hasVariable("", "true"));
+  EXPECT_FALSE(t->hasVariable("", "false"));
 }
 
 TEST_F(RuleOperatorTest, streq) {
@@ -340,8 +340,8 @@ TEST_F(RuleOperatorTest, streq) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true"));
-  EXPECT_FALSE(t->hasVariable("false"));
+  EXPECT_TRUE(t->hasVariable("", "true"));
+  EXPECT_FALSE(t->hasVariable("", "false"));
 }
 
 TEST_F(RuleOperatorTest, streqWithMacro) {
@@ -356,8 +356,8 @@ TEST_F(RuleOperatorTest, streqWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true"));
-  EXPECT_FALSE(t->hasVariable("false"));
+  EXPECT_TRUE(t->hasVariable("", "true"));
+  EXPECT_FALSE(t->hasVariable("", "false"));
 }
 
 TEST_F(RuleOperatorTest, validateUrlEncoding) {
@@ -372,8 +372,8 @@ TEST_F(RuleOperatorTest, validateUrlEncoding) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_FALSE(t->hasVariable("false"));
-  EXPECT_TRUE(t->hasVariable("true"));
+  EXPECT_FALSE(t->hasVariable("", "false"));
+  EXPECT_TRUE(t->hasVariable("", "true"));
 }
 
 TEST_F(RuleOperatorTest, contains) {
@@ -388,8 +388,8 @@ TEST_F(RuleOperatorTest, contains) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true"));
-  EXPECT_FALSE(t->hasVariable("false"));
+  EXPECT_TRUE(t->hasVariable("", "true"));
+  EXPECT_FALSE(t->hasVariable("", "false"));
 }
 
 TEST_F(RuleOperatorTest, containsWithMacro) {
@@ -404,8 +404,8 @@ TEST_F(RuleOperatorTest, containsWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true"));
-  EXPECT_FALSE(t->hasVariable("false"));
+  EXPECT_TRUE(t->hasVariable("", "true"));
+  EXPECT_FALSE(t->hasVariable("", "false"));
 }
 
 TEST_F(RuleOperatorTest, validateByteRange) {
@@ -420,8 +420,8 @@ SecRule TX:bar "@validateByteRange 65,66-68" "id:2,phase:1,setvar:'tx.false'")";
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_TRUE(t->hasVariable("true"));
-  EXPECT_FALSE(t->hasVariable("false"));
+  EXPECT_TRUE(t->hasVariable("", "true"));
+  EXPECT_FALSE(t->hasVariable("", "false"));
 }
 
 TEST_F(RuleOperatorTest, macroLogicMatcher) {
@@ -597,22 +597,22 @@ TEST_F(RuleOperatorTest, macroLogicMatcher) {
   ASSERT_TRUE(result.has_value());
 
   t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-  EXPECT_FALSE(t->hasVariable("v1"));
-  EXPECT_FALSE(t->hasVariable("v2"));
-  EXPECT_FALSE(t->hasVariable("v3"));
-  EXPECT_TRUE(t->hasVariable("v4"));
-  EXPECT_TRUE(t->hasVariable("v5"));
-  EXPECT_TRUE(t->hasVariable("v6"));
-  EXPECT_TRUE(t->hasVariable("v7"));
-  EXPECT_TRUE(t->hasVariable("v8"));
-  EXPECT_TRUE(t->hasVariable("v9"));
-  EXPECT_TRUE(t->hasVariable("v10"));
-  EXPECT_TRUE(t->hasVariable("v11"));
-  EXPECT_TRUE(t->hasVariable("v12"));
-  EXPECT_TRUE(t->hasVariable("v13"));
-  EXPECT_TRUE(t->hasVariable("v14"));
-  EXPECT_TRUE(t->hasVariable("v15"));
-  EXPECT_TRUE(t->hasVariable("v16"));
+  EXPECT_FALSE(t->hasVariable("", "v1"));
+  EXPECT_FALSE(t->hasVariable("", "v2"));
+  EXPECT_FALSE(t->hasVariable("", "v3"));
+  EXPECT_TRUE(t->hasVariable("", "v4"));
+  EXPECT_TRUE(t->hasVariable("", "v5"));
+  EXPECT_TRUE(t->hasVariable("", "v6"));
+  EXPECT_TRUE(t->hasVariable("", "v7"));
+  EXPECT_TRUE(t->hasVariable("", "v8"));
+  EXPECT_TRUE(t->hasVariable("", "v9"));
+  EXPECT_TRUE(t->hasVariable("", "v10"));
+  EXPECT_TRUE(t->hasVariable("", "v11"));
+  EXPECT_TRUE(t->hasVariable("", "v12"));
+  EXPECT_TRUE(t->hasVariable("", "v13"));
+  EXPECT_TRUE(t->hasVariable("", "v14"));
+  EXPECT_TRUE(t->hasVariable("", "v15"));
+  EXPECT_TRUE(t->hasVariable("", "v16"));
 }
 } // namespace Integration
 } // namespace Wge

--- a/test/integration/03_rule_action_test.cc
+++ b/test/integration/03_rule_action_test.cc
@@ -51,7 +51,7 @@ TEST_F(RuleActionTest, ActionSetVar) {
     auto& actions = engine.rules(1).back().actions();
     EXPECT_EQ(actions.size(), 1);
     actions.back()->evaluate(*t);
-    int64_t score = std::get<int64_t>(t->getVariable("score"));
+    int64_t score = std::get<int64_t>(t->getVariable("", "score"));
     EXPECT_EQ(score, 1);
   }
 
@@ -72,8 +72,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
         action->evaluate(*t);
       }
     }
-    EXPECT_EQ(std::get<std::string_view>(t->getVariable("foo")), "bar");
-    int64_t score = std::get<int64_t>(t->getVariable("barscore"));
+    EXPECT_EQ(std::get<std::string_view>(t->getVariable("", "foo")), "bar");
+    int64_t score = std::get<int64_t>(t->getVariable("", "barscore"));
     EXPECT_EQ(score, 1);
   }
 
@@ -91,7 +91,7 @@ TEST_F(RuleActionTest, ActionSetVar) {
     auto& actions = engine.rules(1).back().actions();
     EXPECT_EQ(actions.size(), 1);
     actions.back()->evaluate(*t);
-    int64_t score = std::get<int64_t>(t->getVariable("score2"));
+    int64_t score = std::get<int64_t>(t->getVariable("", "score2"));
     EXPECT_EQ(score, 100);
   }
 
@@ -113,8 +113,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
         action->evaluate(*t);
       }
     }
-    int64_t score2 = std::get<int64_t>(t->getVariable("score2"));
-    int64_t score_bar = std::get<int64_t>(t->getVariable("score_bar"));
+    int64_t score2 = std::get<int64_t>(t->getVariable("", "score2"));
+    int64_t score_bar = std::get<int64_t>(t->getVariable("", "score_bar"));
     EXPECT_EQ(score2, score_bar);
   }
 
@@ -135,9 +135,9 @@ TEST_F(RuleActionTest, ActionSetVar) {
         action->evaluate(*t);
       }
     }
-    int64_t score2 = std::get<int64_t>(t->getVariable("score2"));
-    int64_t score = std::get<int64_t>(t->getVariable("score"));
-    auto foo = std::get<std::string_view>(t->getVariable("foo2"));
+    int64_t score2 = std::get<int64_t>(t->getVariable("", "score2"));
+    int64_t score = std::get<int64_t>(t->getVariable("", "score"));
+    auto foo = std::get<std::string_view>(t->getVariable("", "foo2"));
     EXPECT_EQ(foo, std::format("{}_{}", score2, score));
   }
 
@@ -158,14 +158,14 @@ TEST_F(RuleActionTest, ActionSetVar) {
     auto& actions1 = engine.rules(1).back().actions();
     EXPECT_EQ(actions1.size(), 1);
     actions1.back()->evaluate(*t);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score2")), 1);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score2")), 1);
 
     result = engine.load(rule_directive2);
     engine.init();
     auto& actions2 = engine.rules(1).back().actions();
     EXPECT_EQ(actions2.size(), 1);
     actions2.back()->evaluate(*t);
-    EXPECT_FALSE(t->hasVariable("score2"));
+    EXPECT_FALSE(t->hasVariable("", "score2"));
   }
 
   // Remove (Macro expansion)
@@ -186,8 +186,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions1) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<std::string_view>(t->getVariable("foo")), "bar");
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score_bar")), 1);
+    EXPECT_EQ(std::get<std::string_view>(t->getVariable("", "foo")), "bar");
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score_bar")), 1);
 
     result = engine.load(rule_directive2);
     engine.init();
@@ -195,7 +195,7 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions2) {
       action->evaluate(*t);
     }
-    EXPECT_FALSE(t->hasVariable("score_bar"));
+    EXPECT_FALSE(t->hasVariable("", "score_bar"));
   }
 
   // Increase
@@ -215,7 +215,7 @@ TEST_F(RuleActionTest, ActionSetVar) {
       EXPECT_EQ(actions.size(), 1);
       actions.back()->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score1")), 200);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score1")), 200);
   }
 
   // Increase (value macro expansion)
@@ -236,8 +236,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions1) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score")), 100);
 
     result = engine.load(rule_directive2);
     engine.init();
@@ -247,8 +247,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions2) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 300);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 300);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score")), 100);
   }
 
   // Increase (value macro expansion but not a integer)
@@ -272,8 +272,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions1) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
-    EXPECT_EQ(std::get<std::string_view>(t->getVariable("score")), "hello");
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
+    EXPECT_EQ(std::get<std::string_view>(t->getVariable("", "score")), "hello");
 
     result = engine.load(rule_directive2);
     engine.init();
@@ -283,8 +283,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions2) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
-    EXPECT_EQ(std::get<std::string_view>(t->getVariable("score")), "hello");
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
+    EXPECT_EQ(std::get<std::string_view>(t->getVariable("", "score")), "hello");
 
     result = engine.load(rule_directive3);
     engine.init();
@@ -294,7 +294,7 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions3) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
   }
 
   // Decrease
@@ -314,7 +314,7 @@ TEST_F(RuleActionTest, ActionSetVar) {
       EXPECT_EQ(actions.size(), 1);
       actions.back()->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score1")), 50);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score1")), 50);
   }
 
   // Decrease (value macro expansion)
@@ -335,8 +335,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions1) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score")), 100);
 
     result = engine.load(rule_directive2);
     engine.init();
@@ -346,8 +346,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions2) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 100);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score")), 100);
   }
 
   // Decrease (value macro expansion but not a integer)
@@ -371,8 +371,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions1) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
-    EXPECT_EQ(std::get<std::string_view>(t->getVariable("score")), "hello");
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
+    EXPECT_EQ(std::get<std::string_view>(t->getVariable("", "score")), "hello");
 
     result = engine.load(rule_directive2);
     engine.init();
@@ -382,8 +382,8 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions2) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
-    EXPECT_EQ(std::get<std::string_view>(t->getVariable("score")), "hello");
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
+    EXPECT_EQ(std::get<std::string_view>(t->getVariable("", "score")), "hello");
 
     result = engine.load(rule_directive3);
     engine.init();
@@ -393,7 +393,7 @@ TEST_F(RuleActionTest, ActionSetVar) {
     for (auto& action : actions3) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
   }
 }
 
@@ -412,7 +412,7 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
     auto& actions = engine.rules(1).back().actions();
     EXPECT_EQ(actions.size(), 1);
     actions.back()->evaluate(*t);
-    int64_t score = std::get<int64_t>(t->getVariable("score"));
+    int64_t score = std::get<int64_t>(t->getVariable("", "score"));
     EXPECT_EQ(score, 1);
   }
 
@@ -433,8 +433,8 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
         action->evaluate(*t);
       }
     }
-    EXPECT_EQ(std::get<std::string_view>(t->getVariable("foo")), "bar");
-    int64_t score = std::get<int64_t>(t->getVariable("barscore"));
+    EXPECT_EQ(std::get<std::string_view>(t->getVariable("", "foo")), "bar");
+    int64_t score = std::get<int64_t>(t->getVariable("", "barscore"));
     EXPECT_EQ(score, 1);
   }
 
@@ -452,7 +452,7 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
     auto& actions = engine.rules(1).back().actions();
     EXPECT_EQ(actions.size(), 1);
     actions.back()->evaluate(*t);
-    int64_t score = std::get<int64_t>(t->getVariable("score2"));
+    int64_t score = std::get<int64_t>(t->getVariable("", "score2"));
     EXPECT_EQ(score, 100);
   }
 
@@ -474,8 +474,8 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
         action->evaluate(*t);
       }
     }
-    int64_t score2 = std::get<int64_t>(t->getVariable("score2"));
-    int64_t score_bar = std::get<int64_t>(t->getVariable("score_bar"));
+    int64_t score2 = std::get<int64_t>(t->getVariable("", "score2"));
+    int64_t score_bar = std::get<int64_t>(t->getVariable("", "score_bar"));
     EXPECT_EQ(score2, score_bar);
   }
 
@@ -496,9 +496,9 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
         action->evaluate(*t);
       }
     }
-    int64_t score2 = std::get<int64_t>(t->getVariable("score2"));
-    int64_t score = std::get<int64_t>(t->getVariable("score"));
-    auto foo = std::get<std::string_view>(t->getVariable("foo2"));
+    int64_t score2 = std::get<int64_t>(t->getVariable("", "score2"));
+    int64_t score = std::get<int64_t>(t->getVariable("", "score"));
+    auto foo = std::get<std::string_view>(t->getVariable("", "foo2"));
     EXPECT_EQ(foo, std::format("{}_{}", score2, score));
   }
 
@@ -519,14 +519,14 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
     auto& actions1 = engine.rules(1).back().actions();
     EXPECT_EQ(actions1.size(), 1);
     actions1.back()->evaluate(*t);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score2")), 1);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score2")), 1);
 
     result = engine.load(rule_directive2);
     engine.init();
     auto& actions2 = engine.rules(1).back().actions();
     EXPECT_EQ(actions2.size(), 1);
     actions2.back()->evaluate(*t);
-    EXPECT_FALSE(t->hasVariable("score2"));
+    EXPECT_FALSE(t->hasVariable("", "score2"));
   }
 
   // Remove (Macro expansion)
@@ -547,8 +547,8 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
     for (auto& action : actions1) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<std::string_view>(t->getVariable("foo")), "bar");
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score_bar")), 1);
+    EXPECT_EQ(std::get<std::string_view>(t->getVariable("", "foo")), "bar");
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score_bar")), 1);
 
     result = engine.load(rule_directive2);
     engine.init();
@@ -556,7 +556,7 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
     for (auto& action : actions2) {
       action->evaluate(*t);
     }
-    EXPECT_FALSE(t->hasVariable("score_bar"));
+    EXPECT_FALSE(t->hasVariable("", "score_bar"));
   }
 
   // Increase
@@ -576,7 +576,7 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
       EXPECT_EQ(actions.size(), 1);
       actions.back()->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score1")), 200);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score1")), 200);
   }
 
   // Increase (value macro expansion)
@@ -597,8 +597,8 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
     for (auto& action : actions1) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score")), 100);
 
     result = engine.load(rule_directive2);
     engine.init();
@@ -608,8 +608,8 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
     for (auto& action : actions2) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 300);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 300);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score")), 100);
   }
 
   // Decrease
@@ -629,7 +629,7 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
       EXPECT_EQ(actions.size(), 1);
       actions.back()->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score1")), 50);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score1")), 50);
   }
 
   // Decrease (value macro expansion)
@@ -650,8 +650,8 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
     for (auto& action : actions1) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 200);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 200);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score")), 100);
 
     result = engine.load(rule_directive2);
     engine.init();
@@ -661,8 +661,8 @@ TEST_F(RuleActionTest, ActionSetVarWithNoSigleQuote) {
     for (auto& action : actions2) {
       action->evaluate(*t);
     }
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score200")), 100);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("score")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score200")), 100);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "score")), 100);
   }
 }
 
@@ -702,11 +702,11 @@ TEST_F(RuleActionTest, ActionAllow) {
   t->processRequestBody("", nullptr);
   t->processResponseHeaders("", "", nullptr, nullptr, 0, nullptr);
   t->processResponseBody("", nullptr);
-  EXPECT_TRUE(t->hasVariable("phase1"));
-  EXPECT_FALSE(t->hasVariable("phase1_2"));
-  EXPECT_FALSE(t->hasVariable("phase2"));
-  EXPECT_FALSE(t->hasVariable("phase3"));
-  EXPECT_FALSE(t->hasVariable("phase4"));
+  EXPECT_TRUE(t->hasVariable("", "phase1"));
+  EXPECT_FALSE(t->hasVariable("", "phase1_2"));
+  EXPECT_FALSE(t->hasVariable("", "phase2"));
+  EXPECT_FALSE(t->hasVariable("", "phase3"));
+  EXPECT_FALSE(t->hasVariable("", "phase4"));
 }
 
 TEST_F(RuleActionTest, ActionAllowPhase) {
@@ -729,11 +729,11 @@ TEST_F(RuleActionTest, ActionAllowPhase) {
   t->processRequestBody("", nullptr);
   t->processResponseHeaders("", "", nullptr, nullptr, 0, nullptr);
   t->processResponseBody("", nullptr);
-  EXPECT_TRUE(t->hasVariable("phase1"));
-  EXPECT_FALSE(t->hasVariable("phase1_2"));
-  EXPECT_TRUE(t->hasVariable("phase2"));
-  EXPECT_TRUE(t->hasVariable("phase3"));
-  EXPECT_TRUE(t->hasVariable("phase4"));
+  EXPECT_TRUE(t->hasVariable("", "phase1"));
+  EXPECT_FALSE(t->hasVariable("", "phase1_2"));
+  EXPECT_TRUE(t->hasVariable("", "phase2"));
+  EXPECT_TRUE(t->hasVariable("", "phase3"));
+  EXPECT_TRUE(t->hasVariable("", "phase4"));
 }
 
 TEST_F(RuleActionTest, ActionAllowRequest) {
@@ -756,11 +756,11 @@ TEST_F(RuleActionTest, ActionAllowRequest) {
   t->processRequestBody("", nullptr);
   t->processResponseHeaders("", "", nullptr, nullptr, 0, nullptr);
   t->processResponseBody("", nullptr);
-  EXPECT_TRUE(t->hasVariable("phase1"));
-  EXPECT_FALSE(t->hasVariable("phase1_2"));
-  EXPECT_FALSE(t->hasVariable("phase2"));
-  EXPECT_TRUE(t->hasVariable("phase3"));
-  EXPECT_TRUE(t->hasVariable("phase4"));
+  EXPECT_TRUE(t->hasVariable("", "phase1"));
+  EXPECT_FALSE(t->hasVariable("", "phase1_2"));
+  EXPECT_FALSE(t->hasVariable("", "phase2"));
+  EXPECT_TRUE(t->hasVariable("", "phase3"));
+  EXPECT_TRUE(t->hasVariable("", "phase4"));
 }
 
 TEST_F(RuleActionTest, ActionFirstMatch) {
@@ -776,7 +776,7 @@ TEST_F(RuleActionTest, ActionFirstMatch) {
     engine.init();
     auto t = engine.makeTransaction();
     t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("result")), 3);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "result")), 3);
   }
 
   {
@@ -791,7 +791,7 @@ TEST_F(RuleActionTest, ActionFirstMatch) {
     engine.init();
     auto t = engine.makeTransaction();
     t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("result")), 1);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "result")), 1);
   }
 }
 
@@ -808,7 +808,7 @@ TEST_F(RuleActionTest, ActionEmptyMatch) {
     engine.init();
     auto t = engine.makeTransaction();
     t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-    EXPECT_FALSE(t->hasVariable("result"));
+    EXPECT_FALSE(t->hasVariable("", "result"));
   }
 
   {
@@ -823,7 +823,7 @@ TEST_F(RuleActionTest, ActionEmptyMatch) {
     engine.init();
     auto t = engine.makeTransaction();
     t->processRequestHeaders(nullptr, nullptr, 0, nullptr);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("result")), 1);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "result")), 1);
   }
 }
 

--- a/test/integration/04_rule_evaluate_logic_test.cc
+++ b/test/integration/04_rule_evaluate_logic_test.cc
@@ -59,7 +59,7 @@ TEST(RuleEvaluateLogicTest, evluateLogic) {
           *matched = true;
         },
         &matched);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("test")), 3);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "test")), 3);
     EXPECT_TRUE(matched);
     EXPECT_EQ(t->getMsgMacroExpanded(), "tx.test=3");
     EXPECT_EQ(t->getLogDataMacroExpanded(), "TX:foo4=bar TX:foo1=bar");
@@ -97,11 +97,11 @@ TEST(RuleEvaluateLogicTest, evluateLogic) {
           *matched = true;
         },
         &matched);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("test")), 3);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "test")), 3);
     EXPECT_TRUE(matched);
     EXPECT_EQ(t->getMsgMacroExpanded(), "tx.test=3");
     EXPECT_EQ(t->getLogDataMacroExpanded(), "TX:foo4=bar TX:foo1=bar");
-    EXPECT_EQ(std::get<std::string_view>(t->getVariable("chain")), "true");
+    EXPECT_EQ(std::get<std::string_view>(t->getVariable("", "chain")), "true");
   }
 
   // Test that chained rule is not matched, and starter rule is not matched, and the msg and logdata
@@ -137,7 +137,7 @@ TEST(RuleEvaluateLogicTest, evluateLogic) {
           *matched = true;
         },
         &matched);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("test")), 3);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "test")), 3);
     EXPECT_FALSE(matched);
 
     // Even though the rule is not matched, the msg and logdata macro can evluate manually.
@@ -177,7 +177,7 @@ TEST(RuleEvaluateLogicTest, exceptVariable) {
           *matched = true;
         },
         &matched);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("test")), 4);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "test")), 4);
     EXPECT_TRUE(matched);
     EXPECT_EQ(t->getMsgMacroExpanded(), "tx.test=4");
     // The first matched variable is TX:foo3, and last matched variable is TX:foo4.
@@ -214,7 +214,7 @@ TEST(RuleEvaluateLogicTest, exceptVariable) {
           *matched = true;
         },
         &matched);
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("test")), 4);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "test")), 4);
     EXPECT_TRUE(matched);
     EXPECT_EQ(t->getMsgMacroExpanded(), "tx.test=4");
     // The first matched variable is TX:foo3, and last matched variable is TX:foo4.
@@ -251,7 +251,7 @@ TEST(RuleEvaluateLogicTest, exceptVariable) {
           *matched = true;
         },
         &matched);
-    EXPECT_FALSE(t->hasVariable("test"));
+    EXPECT_FALSE(t->hasVariable("", "test"));
     EXPECT_FALSE(matched);
   }
 }
@@ -301,7 +301,7 @@ TEST(RuleEvaluateLogicTest, MatchedVarPush) {
         },
         &matched);
     // The rule is matched, and the action is executed.
-    EXPECT_EQ(std::get<int64_t>(t->getVariable("test")), 1);
+    EXPECT_EQ(std::get<int64_t>(t->getVariable("", "test")), 1);
     EXPECT_TRUE(matched);
   }
 

--- a/test/parser/engine_action_test.cc
+++ b/test/parser/engine_action_test.cc
@@ -78,5 +78,21 @@ TEST_F(EngineActionTest, SecDefaultAction) {
   EXPECT_TRUE(rule2.auditLog());
   EXPECT_EQ(rule2.disruptive(), Rule::Disruptive::PASS);
 }
+
+TEST_F(EngineActionTest, SexTxNamespace) {
+  std::string directive = R"(SecTxNamespace hello)";
+
+  Antlr4::Parser parser;
+  auto result = parser.load(directive);
+  ASSERT_TRUE(result.has_value());
+
+  EXPECT_EQ(parser.getCurrentNamespace(), "hello");
+
+  directive = R"(SecTxNamespace world)";
+  result = parser.load(directive);
+  ASSERT_TRUE(result.has_value());
+
+  EXPECT_EQ(parser.getCurrentNamespace(), "world");
+}
 } // namespace Parsr
 } // namespace Wge

--- a/test/parser/rule_variable_parse_test.cc
+++ b/test/parser/rule_variable_parse_test.cc
@@ -99,5 +99,37 @@ TEST_F(RuleVariableParseTest, PTreeMacro) {
   EXPECT_NE(dynamic_cast<Macro::VariableMacro*>(op->macroLogicMatcher()->macro().get()), nullptr);
 }
 
+TEST_F(RuleVariableParseTest, Tx) {
+  const std::string directive = R"(SecTxNamespace hello
+  SecRule TX:aaa "foo" "id:1,phase:1")";
+
+  Antlr4::Parser parser;
+  auto result = parser.load(directive);
+  ASSERT_TRUE(result.has_value());
+
+  auto& variables = parser.rules()[0].back().variables();
+  EXPECT_EQ(variables.size(), 1);
+  const auto* variable = dynamic_cast<const Variable::Tx*>(variables[0].get());
+  ASSERT_NE(variable, nullptr);
+  EXPECT_EQ(variable->subName(), "aaa");
+  EXPECT_EQ(variable->getNamespace(), "hello");
+}
+
+TEST_F(RuleVariableParseTest, Gtx) {
+  const std::string directive = R"(SecTxNamespace hello
+  SecRule GTX:aaa "foo" "id:1,phase:1")";
+
+  Antlr4::Parser parser;
+  auto result = parser.load(directive);
+  ASSERT_TRUE(result.has_value());
+
+  auto& variables = parser.rules()[0].back().variables();
+  EXPECT_EQ(variables.size(), 1);
+  const auto* variable = dynamic_cast<const Variable::Tx*>(variables[0].get());
+  ASSERT_NE(variable, nullptr);
+  EXPECT_EQ(variable->subName(), "aaa");
+  EXPECT_EQ(variable->getNamespace(), "");
+}
+
 } // namespace Parser
 } // namespace Wge

--- a/test/transformation/cache_test.cc
+++ b/test/transformation/cache_test.cc
@@ -47,7 +47,7 @@ TEST_F(CacheTest, hit) {
   Common::Variant data = test_data;
 
   Common::EvaluateElement transform_buffer(data, "");
-  Variable::Tx variable(std::string("test"), std::nullopt, false, false, "");
+  Variable::Tx variable("", std::string("test"), std::nullopt, false, false, "");
   bool ret = trans->evaluate(*t_, &variable, transform_buffer, transform_buffer);
   EXPECT_TRUE(ret);
   std::string_view result = std::get<std::string_view>(transform_buffer.variant_);


### PR DESCRIPTION
- The `SecTxNamespace` directive has been added to allow setting a namespace for transaction variables. This useful for multiple rule sets to share the same transaction context without conflicts. Each rule set can now define its own namespace, which will be used to scope transaction variables.
- The 'gtx' variable means 'global transaction' and allows different namespaces to share variables. This is useful for scenarios where multiple namespaces need to access and modify the same variable.