### PR TITLE
feat(engine): improve property tree error handling

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -60,7 +60,7 @@ std::expected<bool, std::string> Engine::load(const std::string& directive) {
   return parser_->load(directive);
 }
 
-void Engine::propertyTree(const std::string& json_string) {
+std::expected<bool, std::string> Engine::propertyTree(const std::string& json_string) {
   ASSERT_IS_MAIN_THREAD();
 
   std::istringstream iss(json_string);
@@ -69,7 +69,7 @@ void Engine::propertyTree(const std::string& json_string) {
     boost::property_tree::read_json(iss, temp_ptree);
   } catch (const boost::property_tree::json_parser_error& e) {
     WGE_LOG_ERROR("Failed to parse property tree JSON string: {}", e.what());
-    return;
+    return std::unexpected<std::string>(e.what());
   }
 
   // Convert ptree to PropertyTree
@@ -77,6 +77,8 @@ void Engine::propertyTree(const std::string& json_string) {
   property_tree_string_pool_.clear();
   property_tree_string_pool_.reserve(json_string.size());
   convertPtreeToPropertyTree(temp_ptree, property_tree_);
+
+  return true;
 }
 
 void Engine::init() {

--- a/src/engine.h
+++ b/src/engine.h
@@ -78,8 +78,9 @@ public:
    * We can use the PTREE variable to access the properties, and we must ensure the structure and
    * content are correct.
    * @param json_string JSON string representing engine properties
+   * @result an error string is returned if fails, and returned true otherwise
    */
-  void propertyTree(const std::string& json_string);
+  std::expected<bool, std::string> propertyTree(const std::string& json_string);
 
   using PropertyTree = boost::property_tree::basic_ptree<std::string, Common::Variant>;
 

--- a/test/integration/01_variable.cc
+++ b/test/integration/01_variable.cc
@@ -838,8 +838,9 @@ TEST_F(VariableTest, PTREE) {
     }
 })";
 
-  Engine engine(spdlog::level::trace);
-  engine.propertyTree(json);
+  Engine engine(spdlog::level::off);
+  auto pt_result = engine.propertyTree(json);
+  ASSERT_TRUE(pt_result.has_value());
   engine.init();
   auto t = engine.makeTransaction();
   Common::EvaluateResults result;


### PR DESCRIPTION
Change the Engine::propertyTree method return type from void to an error string if parsing fails