### PR TITLE
feat(rule,antlr4): support or operator combination

### DIFF
--- a/src/antlr4/SecLangParser.g4
+++ b/src/antlr4/SecLangParser.g4
@@ -127,7 +127,7 @@ sec_rule_update_target_by_tag:
 sec_marker: SecMarker ((QUOTE STRING QUOTE) | STRING);
 
 sec_rule:
-	SecRule variables QUOTE operator QUOTE (
+	SecRule variables QUOTE operator (PIPE operator)* QUOTE (
 		QUOTE action (COMMA? action)* QUOTE
 	)?;
 
@@ -1438,7 +1438,11 @@ sec_rule_update_operator_by_id:
 		INT
 		| INT_RANGE
 		| ID_AND_CHAIN_INDEX
-	) (INT | INT_RANGE | ID_AND_CHAIN_INDEX)* QUOTE operator QUOTE;
+	) (INT | INT_RANGE | ID_AND_CHAIN_INDEX)* QUOTE operator (
+		PIPE operator
+	)* QUOTE;
 sec_rule_update_operator_by_tag:
-	SecRuleUpdateOperatorByTag QUOTE STRING QUOTE QUOTE operator QUOTE;
+	SecRuleUpdateOperatorByTag QUOTE STRING QUOTE QUOTE operator (
+		PIPE operator
+	)* QUOTE;
 sec_tx_namespace: SecTxNamespace STRING;

--- a/src/antlr4/visitor.cc
+++ b/src/antlr4/visitor.cc
@@ -936,150 +936,150 @@ std::any Visitor::visitVariable_gtx(Antlr4Gen::SecLangParser::Variable_gtxContex
 }
 
 std::any Visitor::visitOp_begins_with(Antlr4Gen::SecLangParser::Op_begins_withContext* ctx) {
-  return setOperator<Operator::BeginsWith>(ctx);
+  return appendOperator<Operator::BeginsWith>(ctx);
 }
 
 std::any Visitor::visitOp_contains(Antlr4Gen::SecLangParser::Op_containsContext* ctx) {
-  return setOperator<Operator::Contains>(ctx);
+  return appendOperator<Operator::Contains>(ctx);
 }
 
 std::any Visitor::visitOp_contains_word(Antlr4Gen::SecLangParser::Op_contains_wordContext* ctx) {
-  return setOperator<Operator::ContainsWord>(ctx);
+  return appendOperator<Operator::ContainsWord>(ctx);
 }
 
 std::any Visitor::visitOp_detect_sqli(Antlr4Gen::SecLangParser::Op_detect_sqliContext* ctx) {
   std::unique_ptr<Operator::OperatorBase> op = std::make_unique<Operator::DetectSqli>(
       std::string(), ctx->NOT() != nullptr, parser_->currLoadFile());
-  current_rule_->get()->setOperator(std::move(op));
+  current_rule_->get()->appendOperator(std::move(op));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitOp_detect_xss(Antlr4Gen::SecLangParser::Op_detect_xssContext* ctx) {
   std::unique_ptr<Operator::OperatorBase> op = std::make_unique<Operator::DetectXSS>(
       std::string(), ctx->NOT() != nullptr, parser_->currLoadFile());
-  current_rule_->get()->setOperator(std::move(op));
+  current_rule_->get()->appendOperator(std::move(op));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitOp_ends_with(Antlr4Gen::SecLangParser::Op_ends_withContext* ctx) {
-  return setOperator<Operator::EndsWith>(ctx);
+  return appendOperator<Operator::EndsWith>(ctx);
 }
 
 std::any Visitor::visitOp_fuzzy_hash(Antlr4Gen::SecLangParser::Op_fuzzy_hashContext* ctx) {
-  return setOperator<Operator::FuzzyHash>(ctx);
+  return appendOperator<Operator::FuzzyHash>(ctx);
 }
 
 std::any Visitor::visitOp_eq(Antlr4Gen::SecLangParser::Op_eqContext* ctx) {
-  return setOperator<Operator::Eq>(ctx);
+  return appendOperator<Operator::Eq>(ctx);
 }
 
 std::any Visitor::visitOp_ge(Antlr4Gen::SecLangParser::Op_geContext* ctx) {
-  return setOperator<Operator::Ge>(ctx);
+  return appendOperator<Operator::Ge>(ctx);
 }
 
 std::any Visitor::visitOp_geo_lookup(Antlr4Gen::SecLangParser::Op_geo_lookupContext* ctx) {
-  return setOperator<Operator::GeoLookup>(ctx);
+  return appendOperator<Operator::GeoLookup>(ctx);
 }
 
 std::any Visitor::visitOp_gt(Antlr4Gen::SecLangParser::Op_gtContext* ctx) {
-  return setOperator<Operator::Gt>(ctx);
+  return appendOperator<Operator::Gt>(ctx);
 }
 
 std::any Visitor::visitOp_inspect_file(Antlr4Gen::SecLangParser::Op_inspect_fileContext* ctx) {
-  return setOperator<Operator::InspectFile>(ctx);
+  return appendOperator<Operator::InspectFile>(ctx);
 }
 
 std::any Visitor::visitOp_ip_match(Antlr4Gen::SecLangParser::Op_ip_matchContext* ctx) {
-  return setOperator<Operator::IpMatch>(ctx);
+  return appendOperator<Operator::IpMatch>(ctx);
 }
 
 std::any Visitor::visitOp_ip_match_f(Antlr4Gen::SecLangParser::Op_ip_match_fContext* ctx) {
-  return setOperator<Operator::IpMatchFromFile>(ctx);
+  return appendOperator<Operator::IpMatchFromFile>(ctx);
 }
 
 std::any
 Visitor::visitOp_ip_match_from_file(Antlr4Gen::SecLangParser::Op_ip_match_from_fileContext* ctx) {
-  return setOperator<Operator::IpMatchFromFile>(ctx);
+  return appendOperator<Operator::IpMatchFromFile>(ctx);
 }
 
 std::any Visitor::visitOp_le(Antlr4Gen::SecLangParser::Op_leContext* ctx) {
-  return setOperator<Operator::Le>(ctx);
+  return appendOperator<Operator::Le>(ctx);
 }
 
 std::any Visitor::visitOp_lt(Antlr4Gen::SecLangParser::Op_ltContext* ctx) {
-  return setOperator<Operator::Lt>(ctx);
+  return appendOperator<Operator::Lt>(ctx);
 }
 
 std::any Visitor::visitOp_no_match(Antlr4Gen::SecLangParser::Op_no_matchContext* ctx) {
   std::unique_ptr<Operator::OperatorBase> op = std::make_unique<Operator::NoMatch>(
       std::string(), ctx->NOT() != nullptr, parser_->currLoadFile());
-  current_rule_->get()->setOperator(std::move(op));
+  current_rule_->get()->appendOperator(std::move(op));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitOp_pm(Antlr4Gen::SecLangParser::Op_pmContext* ctx) {
-  return setOperator<Operator::Pm>(ctx);
+  return appendOperator<Operator::Pm>(ctx);
 }
 
 std::any Visitor::visitOp_pmf(Antlr4Gen::SecLangParser::Op_pmfContext* ctx) {
-  return setOperator<Operator::PmFromFile>(ctx);
+  return appendOperator<Operator::PmFromFile>(ctx);
 }
 
 std::any Visitor::visitOp_pm_from_file(Antlr4Gen::SecLangParser::Op_pm_from_fileContext* ctx) {
-  return setOperator<Operator::PmFromFile>(ctx);
+  return appendOperator<Operator::PmFromFile>(ctx);
 }
 
 std::any Visitor::visitOp_rbl(Antlr4Gen::SecLangParser::Op_rblContext* ctx) {
-  return setOperator<Operator::Rbl>(ctx);
+  return appendOperator<Operator::Rbl>(ctx);
 }
 
 std::any Visitor::visitOp_rsub(Antlr4Gen::SecLangParser::Op_rsubContext* ctx) {
-  return setOperator<Operator::Rsub>(ctx);
+  return appendOperator<Operator::Rsub>(ctx);
 }
 
 std::any Visitor::visitOp_rx(Antlr4Gen::SecLangParser::Op_rxContext* ctx) {
-  return setOperator<Operator::Rx>(ctx);
+  return appendOperator<Operator::Rx>(ctx);
 }
 
 std::any Visitor::visitOp_rx_global(Antlr4Gen::SecLangParser::Op_rx_globalContext* ctx) {
-  return setOperator<Operator::RxGlobal>(ctx);
+  return appendOperator<Operator::RxGlobal>(ctx);
 }
 
 std::any Visitor::visitOp_streq(Antlr4Gen::SecLangParser::Op_streqContext* ctx) {
-  return setOperator<Operator::Streq>(ctx);
+  return appendOperator<Operator::Streq>(ctx);
 }
 
 std::any Visitor::visitOp_strmatch(Antlr4Gen::SecLangParser::Op_strmatchContext* ctx) {
-  return setOperator<Operator::Strmatch>(ctx);
+  return appendOperator<Operator::Strmatch>(ctx);
 }
 
 std::any
 Visitor::visitOp_unconditional_match(Antlr4Gen::SecLangParser::Op_unconditional_matchContext* ctx) {
   std::unique_ptr<Operator::OperatorBase> op = std::make_unique<Operator::UnconditionalMatch>(
       std::string(), ctx->NOT() != nullptr, parser_->currLoadFile());
-  current_rule_->get()->setOperator(std::move(op));
+  current_rule_->get()->appendOperator(std::move(op));
   return EMPTY_STRING;
 }
 
 std::any
 Visitor::visitOp_validate_byte_range(Antlr4Gen::SecLangParser::Op_validate_byte_rangeContext* ctx) {
-  return setOperator<Operator::ValidateByteRange>(ctx);
+  return appendOperator<Operator::ValidateByteRange>(ctx);
 }
 
 std::any Visitor::visitOp_validate_dtd(Antlr4Gen::SecLangParser::Op_validate_dtdContext* ctx) {
-  return setOperator<Operator::ValidateDTD>(ctx);
+  return appendOperator<Operator::ValidateDTD>(ctx);
 }
 
 std::any
 Visitor::visitOp_validate_schema(Antlr4Gen::SecLangParser::Op_validate_schemaContext* ctx) {
-  return setOperator<Operator::ValidateSchema>(ctx);
+  return appendOperator<Operator::ValidateSchema>(ctx);
 }
 
 std::any Visitor::visitOp_validate_url_encoding(
     Antlr4Gen::SecLangParser::Op_validate_url_encodingContext* ctx) {
   std::unique_ptr<Operator::OperatorBase> op = std::make_unique<Operator::ValidateUrlEncoding>(
       std::string(), ctx->NOT() != nullptr, parser_->currLoadFile());
-  current_rule_->get()->setOperator(std::move(op));
+  current_rule_->get()->appendOperator(std::move(op));
   return EMPTY_STRING;
 }
 
@@ -1087,24 +1087,24 @@ std::any Visitor::visitOp_validate_utf8_encoding(
     Antlr4Gen::SecLangParser::Op_validate_utf8_encodingContext* ctx) {
   std::unique_ptr<Operator::OperatorBase> op = std::make_unique<Operator::ValidateUtf8Encoding>(
       std::string(), ctx->NOT() != nullptr, parser_->currLoadFile());
-  current_rule_->get()->setOperator(std::move(op));
+  current_rule_->get()->appendOperator(std::move(op));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitOp_verify_cc(Antlr4Gen::SecLangParser::Op_verify_ccContext* ctx) {
-  return setOperator<Operator::VerifyCC>(ctx);
+  return appendOperator<Operator::VerifyCC>(ctx);
 }
 
 std::any Visitor::visitOp_verify_cpf(Antlr4Gen::SecLangParser::Op_verify_cpfContext* ctx) {
-  return setOperator<Operator::VerifyCPF>(ctx);
+  return appendOperator<Operator::VerifyCPF>(ctx);
 }
 
 std::any Visitor::visitOp_verify_ssn(Antlr4Gen::SecLangParser::Op_verify_ssnContext* ctx) {
-  return setOperator<Operator::VerifySSN>(ctx);
+  return appendOperator<Operator::VerifySSN>(ctx);
 }
 
 std::any Visitor::visitOp_within(Antlr4Gen::SecLangParser::Op_withinContext* ctx) {
-  return setOperator<Operator::Within>(ctx);
+  return appendOperator<Operator::Within>(ctx);
 }
 
 std::any Visitor::visitOp_rx_default(Antlr4Gen::SecLangParser::Op_rx_defaultContext* ctx) {
@@ -1124,12 +1124,12 @@ std::any Visitor::visitOp_rx_default(Antlr4Gen::SecLangParser::Op_rx_defaultCont
         new Operator::Rx(ctx->string_with_macro()->getText(), false, parser_->currLoadFile()));
   }
 
-  current_rule_->get()->setOperator(std::move(op));
+  current_rule_->get()->appendOperator(std::move(op));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitOp_xor(Antlr4Gen::SecLangParser::Op_xorContext* ctx) {
-  return setOperator<Operator::Xor>(ctx);
+  return appendOperator<Operator::Xor>(ctx);
 }
 
 std::any
@@ -2367,6 +2367,9 @@ std::any Visitor::visitSec_rule_update_operator_by_id(
     uint64_t id_num = ::atoll(id_str.c_str());
     current_rule_ = std::make_unique<CurrentRule>(parser_, id_num);
     if (current_rule_->get()) {
+      // Clear existing operators
+      current_rule_->get()->clearOperators();
+
       // Visit operator
       std::string error;
       current_rule_->visitOperatorMode(CurrentRule::VisitOperatorMode::SecRuleUpdateOperator);
@@ -2387,6 +2390,9 @@ std::any Visitor::visitSec_rule_update_operator_by_id(
       for (auto id = first; id <= last; ++id) {
         current_rule_ = std::make_unique<CurrentRule>(parser_, id);
         if (current_rule_->get()) {
+          // Clear existing operators
+          current_rule_->get()->clearOperators();
+
           // Visit operator
           std::string error;
           current_rule_->visitOperatorMode(CurrentRule::VisitOperatorMode::SecRuleUpdateOperator);
@@ -2413,6 +2419,10 @@ std::any Visitor::visitSec_rule_update_operator_by_id(
       Rule* chain_rule = current_rule_->get()->chainRule(chain_index);
       if (chain_rule) {
         current_rule_ = std::make_unique<CurrentRule>(parser_, chain_rule);
+
+        // Clear existing operators
+        current_rule_->get()->clearOperators();
+
         // Visit operator
         std::string error;
         current_rule_->visitOperatorMode(CurrentRule::VisitOperatorMode::SecRuleUpdateOperator);
@@ -2432,6 +2442,10 @@ std::any Visitor::visitSec_rule_update_operator_by_tag(
   auto rules = parser_->findRuleByTag(ctx->STRING()->getText());
   for (auto rule : rules) {
     current_rule_ = std::make_unique<CurrentRule>(parser_, rule);
+
+    // Clear existing operators
+    current_rule_->get()->clearOperators();
+
     // Visit operator
     std::string error;
     current_rule_->visitOperatorMode(CurrentRule::VisitOperatorMode::SecRuleUpdateOperator);

--- a/src/antlr4/visitor.h
+++ b/src/antlr4/visitor.h
@@ -994,7 +994,7 @@ private:
     }
   }
 
-  template <class OperatorT, class CtxT> std::any setOperator(CtxT* ctx) {
+  template <class OperatorT, class CtxT> std::any appendOperator(CtxT* ctx) {
     std::expected<std::unique_ptr<Macro::MacroBase>, std::string> macro =
         getMacro(ctx->string_with_macro()->getText(), ctx->string_with_macro()->variable(),
                  ctx->string_with_macro()->STRING().empty());
@@ -1009,8 +1009,8 @@ private:
       if (current_rule_->visitOperatorMode() ==
           CurrentRule::VisitOperatorMode::SecRuleUpdateOperator) {
         // In the SecRuleUpdateOperator mode:
-        // - If the macro type is VariableMacro and the variable is RULE.operator_value, we need
-        // expand the macro to get the original value of the operator.
+        // - If the macro type is VariableMacro and the variable is RULE.operator_value, we reject
+        // it
         // - If the macro type is VariableMacro but the varaible is not RULE.operator_value, we use
         // it directly.
         // - If the macro type is MultiMacro, we don't support it yet.
@@ -1020,17 +1020,8 @@ private:
           std::string_view variable_main_name = variable_macro_ptr->getVariable()->mainName();
           const std::string& variable_sub_name = variable_macro_ptr->getVariable()->subName();
           if (variable_main_name == "RULE" && variable_sub_name == "operator_value") {
-            std::string original_operator_literal_value =
-                current_rule_->get()->getOperator()->literalValue();
-            if (!original_operator_literal_value.empty()) {
-              op = std::unique_ptr<Operator::OperatorBase>(
-                  new OperatorT(std::move(original_operator_literal_value), ctx->NOT() != nullptr,
-                                parser_->currLoadFile()));
-            } else {
-              op = std::unique_ptr<Operator::OperatorBase>(new OperatorT(
-                  std::move(current_rule_->get()->getOperator()->macroLogicMatcher()->macro()),
-                  ctx->NOT() != nullptr, parser_->currLoadFile()));
-            }
+            assert(false);
+            RETURN_ERROR("%{RULE.operator_value} is not supported yet in SecRuleUpdateOperator.");
           } else {
             op = std::unique_ptr<Operator::OperatorBase>(new OperatorT(
                 std::move(macro_ptr), ctx->NOT() != nullptr, parser_->currLoadFile()));
@@ -1053,7 +1044,7 @@ private:
           ctx->string_with_macro()->getText(), ctx->NOT() != nullptr, parser_->currLoadFile()));
     }
 
-    current_rule_->get()->setOperator(std::move(op));
+    current_rule_->get()->appendOperator(std::move(op));
     return EMPTY_STRING;
   }
 

--- a/src/rule.h
+++ b/src/rule.h
@@ -195,8 +195,11 @@ public:
   const std::unordered_map<Variable::FullName, Variable::VariableBase&>& variablesIndex() const {
     return detail_->variables_index_by_full_name_;
   }
-  void setOperator(std::unique_ptr<Operator::OperatorBase>&& op);
-  const std::unique_ptr<Operator::OperatorBase>& getOperator() const { return operator_; }
+  void appendOperator(std::unique_ptr<Operator::OperatorBase>&& op);
+  const std::vector<std::unique_ptr<Operator::OperatorBase>>& operators() const {
+    return operators_;
+  }
+  void clearOperators() { operators_.clear(); }
   void appendChainRule(std::unique_ptr<Rule>&& rule);
 
   /**
@@ -340,7 +343,7 @@ private:
 
   std::vector<std::unique_ptr<Variable::VariableBase>> variables_;
   std::vector<std::unique_ptr<Transformation::TransformBase>> transforms_;
-  std::unique_ptr<Operator::OperatorBase> operator_;
+  std::vector<std::unique_ptr<Operator::OperatorBase>> operators_;
   std::vector<std::unique_ptr<Action::ActionBase>> actions_;
 
   // Chains the current rule with the rule that immediately follows it, creating a rule chain.

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -682,9 +682,7 @@ inline bool Transaction::process(RulePhaseType phase) {
     // Evaluate the rule
     auto is_matched = current_rule_->evaluate(*this);
 
-    if (!is_matched ||
-        current_rule_->getOperator() == nullptr // It's a rule that defined by SecAction
-    )
+    if (!is_matched || current_rule_->operators().empty())
       [[likely]] {
         ++iter;
         continue;

--- a/src/variable/rule.cc
+++ b/src/variable/rule.cc
@@ -48,19 +48,14 @@ void Rule::initEvaluateFunc() {
            }},
           {"operator_value", [](Transaction& t, Common::EvaluateResults& result, bool is_count) {
              if (is_count) {
-               if (t.getCurrentEvaluateRule()->getOperator()->literalValue().empty() &&
-                   t.getCurrentEvaluateRule()->getOperator()->macroLogicMatcher() == nullptr) {
-                 result.emplace_back(0, "operator_value");
-               } else {
-                 result.emplace_back(1, "operator_value");
-               }
-
+               result.emplace_back(
+                   static_cast<int64_t>(t.getCurrentEvaluateRule()->operators().size()),
+                   "operator_value");
                return;
              }
 
-             if (!t.getCurrentEvaluateRule()->getOperator()->literalValue().empty()) {
-               result.emplace_back(t.getCurrentEvaluateRule()->getOperator()->literalValue(),
-                                   "operator_value");
+             for (auto& op : t.getCurrentEvaluateRule()->operators()) {
+               result.emplace_back(op->literalValue(), "operator_value");
              }
            }}};
   std::string sub_name_ignore_case;

--- a/test/parser/engine_action_test.cc
+++ b/test/parser/engine_action_test.cc
@@ -47,7 +47,7 @@ TEST_F(EngineActionTest, SecAction) {
   auto& rule = rules.front();
   EXPECT_EQ(rule.id(), 1);
   EXPECT_EQ(rule.phase(), 2);
-  EXPECT_EQ(rule.getOperator(), nullptr);
+  EXPECT_EQ(rule.operators().size(), 0);
 
   auto& actions = rule.actions();
   EXPECT_EQ(actions.size(), 2);

--- a/test/parser/rule_action_parse_test.cc
+++ b/test/parser/rule_action_parse_test.cc
@@ -544,7 +544,7 @@ SecRule ARGS_GET|ARGS_POST:foo|!ARGS_GET:foo|&ARGS "bar" "id:2,tag:'foo',msg:'ba
   }
 
   // Operator
-  auto& rule_operator = chain_rule->getOperator();
+  auto& rule_operator = chain_rule->operators().front();
   EXPECT_EQ(rule_operator->name(), std::string("rx"));
   EXPECT_EQ(rule_operator->literalValue(), "bar");
 
@@ -753,7 +753,7 @@ TEST_F(RuleActionParseTest, ActionIdWithString) {
   }
 
   // operator
-  auto& rule_operator = parser.rules()[0].back().getOperator();
+  auto& rule_operator = parser.rules()[0].back().operators().front();
   EXPECT_EQ(rule_operator->name(), std::string("rx"));
   EXPECT_EQ(rule_operator->literalValue(), "bar");
 }

--- a/test/parser/rule_directive_test.cc
+++ b/test/parser/rule_directive_test.cc
@@ -94,7 +94,7 @@ TEST_F(RuleTest, Rule) {
   }
 
   // operator
-  auto& rule_operator = parser.rules()[0].back().getOperator();
+  auto& rule_operator = parser.rules()[0].back().operators().front();
   EXPECT_EQ(rule_operator->name(), std::string("rx"));
   EXPECT_EQ(rule_operator->literalValue(), "bar");
 }

--- a/test/parser/rule_operator_parse_test.cc
+++ b/test/parser/rule_operator_parse_test.cc
@@ -50,7 +50,7 @@ TEST_F(RuleOperatorParseTest, beginsWith) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("beginsWith"));
   EXPECT_EQ(op->literalValue(), "ba");
 }
@@ -64,7 +64,7 @@ TEST_F(RuleOperatorParseTest, beginsWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("beginsWith"));
   EXPECT_EQ(op->literalValue(), "");
   auto& macro_matcher = op->macroLogicMatcher();
@@ -83,7 +83,7 @@ TEST_F(RuleOperatorParseTest, endsWith) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("endsWith"));
   EXPECT_EQ(op->literalValue(), "ar");
 }
@@ -97,7 +97,7 @@ TEST_F(RuleOperatorParseTest, endsWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("endsWith"));
   EXPECT_EQ(op->literalValue(), "");
   auto& macro_matcher = op->macroLogicMatcher();
@@ -122,20 +122,21 @@ TEST_F(RuleOperatorParseTest, ipMatch) {
   EXPECT_EQ(rules.size(), 4);
   size_t i = 0;
   for (auto& rule : rules) {
-    auto& op = rule.getOperator();
+    auto& op = rule.operators().front();
     EXPECT_EQ(op->name(), std::string_view("ipMatch"));
     switch (i) {
     case 0:
-      EXPECT_EQ(rule.getOperator()->literalValue(), "192.168.1.1");
+      EXPECT_EQ(rule.operators().front()->literalValue(), "192.168.1.1");
       break;
     case 1:
-      EXPECT_EQ(rule.getOperator()->literalValue(), "192.168.1.0/24");
+      EXPECT_EQ(rule.operators().front()->literalValue(), "192.168.1.0/24");
       break;
     case 2:
-      EXPECT_EQ(rule.getOperator()->literalValue(), "2001:db8:85a3:8d3:1319:8a2e:370:7349");
+      EXPECT_EQ(rule.operators().front()->literalValue(), "2001:db8:85a3:8d3:1319:8a2e:370:7349");
       break;
     case 3:
-      EXPECT_EQ(rule.getOperator()->literalValue(), "2001:db8:85a3:8d3:1319:8a2e:270:0000/24");
+      EXPECT_EQ(rule.operators().front()->literalValue(),
+                "2001:db8:85a3:8d3:1319:8a2e:270:0000/24");
       break;
     default:
       ASSERT_TRUE(false);
@@ -154,7 +155,7 @@ TEST_F(RuleOperatorParseTest, pm) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("pm"));
   EXPECT_EQ(op->literalValue(), "hello1 world1");
 }
@@ -168,7 +169,7 @@ TEST_F(RuleOperatorParseTest, within) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("within"));
   EXPECT_EQ(op->literalValue(), "hello1 world1");
 }
@@ -182,7 +183,7 @@ TEST_F(RuleOperatorParseTest, withinWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("within"));
   EXPECT_EQ(op->literalValue(), "");
   auto& macro_matcher = op->macroLogicMatcher();
@@ -201,7 +202,7 @@ TEST_F(RuleOperatorParseTest, rx) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("rx"));
   EXPECT_EQ(op->literalValue(), R"(^\w+\d+\w+$)");
 }
@@ -215,7 +216,7 @@ TEST_F(RuleOperatorParseTest, rxWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("rx"));
   EXPECT_EQ(op->literalValue(), "");
   auto& macro_matcher = op->macroLogicMatcher();
@@ -234,7 +235,7 @@ TEST_F(RuleOperatorParseTest, pmFromFile) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("pmFromFile"));
   EXPECT_EQ(op->literalValue(), R"(test/test_data/pmf_test.data)");
 }
@@ -248,7 +249,7 @@ TEST_F(RuleOperatorParseTest, streq) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("streq"));
   EXPECT_EQ(op->literalValue(), "helloworld1");
 }
@@ -262,7 +263,7 @@ TEST_F(RuleOperatorParseTest, streqWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("streq"));
   EXPECT_EQ(op->literalValue(), "");
   auto& macro_matcher = op->macroLogicMatcher();
@@ -281,7 +282,7 @@ TEST_F(RuleOperatorParseTest, validateUrlEncoding) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("validateUrlEncoding"));
   EXPECT_EQ(op->literalValue(), "");
 }
@@ -295,7 +296,7 @@ TEST_F(RuleOperatorParseTest, contains) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("contains"));
   EXPECT_EQ(op->literalValue(), "hello1");
 }
@@ -309,7 +310,7 @@ TEST_F(RuleOperatorParseTest, containsWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("contains"));
   EXPECT_EQ(op->literalValue(), "");
   auto& macro_matcher = op->macroLogicMatcher();
@@ -328,7 +329,7 @@ TEST_F(RuleOperatorParseTest, validateByteRange) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("validateByteRange"));
   EXPECT_EQ(op->literalValue(), "65,66-68");
 }
@@ -341,7 +342,7 @@ TEST_F(RuleOperatorParseTest, xor) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("xor"));
   EXPECT_EQ(op->literalValue(), "0");
 }
@@ -354,7 +355,7 @@ TEST_F(RuleOperatorParseTest, xorWithMacro) {
   ASSERT_TRUE(result.has_value());
 
   auto& rule = parser.rules()[0].back();
-  auto& op = rule.getOperator();
+  auto& op = rule.operators().front();
   EXPECT_EQ(op->name(), std::string_view("xor"));
   EXPECT_EQ(op->literalValue(), "");
   auto& macro_matcher = op->macroLogicMatcher();
@@ -362,6 +363,39 @@ TEST_F(RuleOperatorParseTest, xorWithMacro) {
   auto& macro = macro_matcher->macro();
   ASSERT_NE(macro, nullptr);
   EXPECT_EQ(macro->literalValue(), "%{TX.bar}");
+}
+
+TEST_F(RuleOperatorParseTest, operatorCombination) {
+  const std::string directive =
+      R"(SecRule TX:bar "@beginsWith bar|@endsWith ar|@contains %{tx.foo}|@rx %{tx.foo2}" "id:2,phase:1,setvar:'tx.false'")";
+
+  Antlr4::Parser parser;
+  auto result = parser.load(directive);
+  ASSERT_TRUE(result.has_value());
+
+  auto& rule = parser.rules()[0].back();
+  auto& operators = rule.operators();
+  ASSERT_EQ(operators.size(), 4);
+  EXPECT_EQ(operators[0]->name(), std::string_view("beginsWith"));
+  EXPECT_EQ(operators[0]->literalValue(), "bar");
+  EXPECT_EQ(operators[1]->name(), std::string_view("endsWith"));
+  EXPECT_EQ(operators[1]->literalValue(), "ar");
+  EXPECT_EQ(operators[2]->name(), std::string_view("contains"));
+  EXPECT_EQ(operators[2]->literalValue(), "");
+  auto& macro_matcher = operators[2]->macroLogicMatcher();
+  ASSERT_NE(macro_matcher, nullptr);
+  auto& macro = macro_matcher->macro();
+  ASSERT_NE(macro, nullptr);
+  EXPECT_EQ(macro->literalValue(), "%{TX.foo}");
+  {
+    EXPECT_EQ(operators[3]->name(), std::string_view("rx"));
+    EXPECT_EQ(operators[3]->literalValue(), "");
+    auto& macro_matcher = operators[3]->macroLogicMatcher();
+    ASSERT_NE(macro_matcher, nullptr);
+    auto& macro = macro_matcher->macro();
+    ASSERT_NE(macro, nullptr);
+    EXPECT_EQ(macro->literalValue(), "%{TX.foo2}");
+  }
 }
 } // namespace Parser
 } // namespace Wge

--- a/test/parser/rule_variable_parse_test.cc
+++ b/test/parser/rule_variable_parse_test.cc
@@ -92,7 +92,7 @@ TEST_F(RuleVariableParseTest, PTreeMacro) {
   auto result = parser.load(directive);
   ASSERT_TRUE(result.has_value());
 
-  auto& op = parser.rules()[0].back().getOperator();
+  auto& op = parser.rules()[0].back().operators().front();
   EXPECT_NE(op->macroLogicMatcher(), nullptr);
   EXPECT_EQ(op->macroLogicMatcher()->macro()->literalValue(),
             "%{PTREE.config.server_list[&].domain{}}");


### PR DESCRIPTION
The 'or' operator combination is now supported in rule definitions, allowing multiple conditions to be evaluated with logical OR semantics. Example:
```
SecRule ARGS "@streq test|@rx hellword|@beginsWith hi" "id:1,phase:2"
```