### PR TITLE
feat: support unmatched/always actions in rules

### DIFF
--- a/src/action/action_base.h
+++ b/src/action/action_base.h
@@ -35,11 +35,21 @@ namespace Wge {
 namespace Action {
 class ActionBase {
 public:
+  enum class Branch { Matched, Unmatched, Always };
+
+public:
+  ActionBase(Branch branch) : branch_(branch){};
   virtual ~ActionBase() = default;
 
 public:
   virtual void evaluate(Transaction& t) const = 0;
   virtual const char* name() const = 0;
+
+public:
+  Branch branch() const { return branch_; }
+
+private:
+  Branch branch_;
 };
 } // namespace Action
 } // namespace Wge

--- a/src/action/ctl.cc
+++ b/src/action/ctl.cc
@@ -27,7 +27,8 @@
 
 namespace Wge {
 namespace Action {
-Ctl::Ctl(CtlType type, std::any&& value) : type_(type), value_(std::move(value)) {
+Ctl::Ctl(ActionBase::Branch branch, CtlType type, std::any&& value)
+    : ActionBase(branch), type_(type), value_(std::move(value)) {
   switch (type_) {
   case CtlType::AuditEngine:
     evaluate_func_ = std::bind(&Ctl::evaluate_audit_engine, this, std::placeholders::_1);

--- a/src/action/ctl.h
+++ b/src/action/ctl.h
@@ -58,7 +58,7 @@ public:
   };
 
 public:
-  Ctl(CtlType type, std::any&& value);
+  Ctl(ActionBase::Branch branch, CtlType type, std::any&& value);
 
 public:
   void evaluate(Transaction& t) const override { evaluate_func_(t); }

--- a/src/action/initcol.cc
+++ b/src/action/initcol.cc
@@ -24,12 +24,13 @@
 
 namespace Wge {
 namespace Action {
-InitCol::InitCol(PersistentStorage::Storage::Type type, std::string&& key, std::string&& value)
-    : type_(type), key_(std::move(key)), value_(std::move(value)) {}
+InitCol::InitCol(ActionBase::Branch branch, PersistentStorage::Storage::Type type,
+                 std::string&& key, std::string&& value)
+    : ActionBase(branch), type_(type), key_(std::move(key)), value_(std::move(value)) {}
 
-InitCol::InitCol(PersistentStorage::Storage::Type type, std::string&& key,
-                 std::unique_ptr<Macro::MacroBase>&& value)
-    : type_(type), key_(std::move(key)), value_macro_(std::move(value)) {}
+InitCol::InitCol(ActionBase::Branch branch, PersistentStorage::Storage::Type type,
+                 std::string&& key, std::unique_ptr<Macro::MacroBase>&& value)
+    : ActionBase(branch), type_(type), key_(std::move(key)), value_macro_(std::move(value)) {}
 
 void InitCol::evaluate(Transaction& t) const {
   if (value_macro_) {

--- a/src/action/initcol.h
+++ b/src/action/initcol.h
@@ -31,12 +31,17 @@ class InitCol final : public ActionBase {
   DECLARE_ACTION_NAME(initcol);
 
 public:
-  InitCol(PersistentStorage::Storage::Type type, std::string&& key, std::string&& value);
-  InitCol(PersistentStorage::Storage::Type type, std::string&& key,
+  InitCol(ActionBase::Branch branch, PersistentStorage::Storage::Type type, std::string&& key,
+          std::string&& value);
+  InitCol(ActionBase::Branch branch, PersistentStorage::Storage::Type type, std::string&& key,
           std::unique_ptr<Macro::MacroBase>&& value);
 
 public:
   void evaluate(Transaction& t) const override;
+
+public:
+  const std::string& key() const { return key_; }
+  const std::string& value() const { return value_; }
 
 private:
   std::string key_;

--- a/src/action/set_env.cc
+++ b/src/action/set_env.cc
@@ -26,15 +26,16 @@
 
 namespace Wge {
 namespace Action {
-SetEnv::SetEnv(std::string&& key, std::string&& value)
-    : key_(std::move(key)), value_(std::move(value)) {
+SetEnv::SetEnv(ActionBase::Branch branch, std::string&& key, std::string&& value)
+    : ActionBase(branch), key_(std::move(key)), value_(std::move(value)) {
   // The variable name is case insensitive
   std::transform(key_.begin(), key_.end(), key_.begin(),
                  [](unsigned char c) { return std::tolower(c); });
 }
 
-SetEnv::SetEnv(std::string&& key, std::unique_ptr<Macro::MacroBase>&& macro)
-    : key_(std::move(key)), macro_(std::move(macro)) {
+SetEnv::SetEnv(ActionBase::Branch branch, std::string&& key,
+               std::unique_ptr<Macro::MacroBase>&& macro)
+    : ActionBase(branch), key_(std::move(key)), macro_(std::move(macro)) {
   // The variable name is case insensitive
   std::transform(key_.begin(), key_.end(), key_.begin(),
                  [](unsigned char c) { return std::tolower(c); });

--- a/src/action/set_env.h
+++ b/src/action/set_env.h
@@ -34,11 +34,15 @@ class SetEnv final : public ActionBase {
   DECLARE_ACTION_NAME(setenv);
 
 public:
-  SetEnv(std::string&& key, std::string&& value);
-  SetEnv(std::string&& key, std::unique_ptr<Macro::MacroBase>&& macro);
+  SetEnv(ActionBase::Branch branch, std::string&& key, std::string&& value);
+  SetEnv(ActionBase::Branch branch, std::string&& key, std::unique_ptr<Macro::MacroBase>&& macro);
 
 public:
   void evaluate(Transaction& t) const override;
+
+public:
+  const std::string& key() const { return key_; }
+  const std::string& value() const { return value_; }
 
 private:
   std::string key_;

--- a/src/action/set_rsc.cc
+++ b/src/action/set_rsc.cc
@@ -22,9 +22,11 @@
 
 namespace Wge {
 namespace Action {
-SetRsc::SetRsc(std::string&& value) : value_(std::move(value)) {}
+SetRsc::SetRsc(ActionBase::Branch branch, std::string&& value)
+    : ActionBase(branch), value_(std::move(value)) {}
 
-SetRsc::SetRsc(std::unique_ptr<Macro::MacroBase>&& macro) : macro_(std::move(macro)) {}
+SetRsc::SetRsc(ActionBase::Branch branch, std::unique_ptr<Macro::MacroBase>&& macro)
+    : ActionBase(branch), macro_(std::move(macro)) {}
 
 void SetRsc::evaluate(Transaction& t) const { throw "Not implemented!"; }
 } // namespace Action

--- a/src/action/set_rsc.h
+++ b/src/action/set_rsc.h
@@ -37,11 +37,14 @@ class SetRsc final : public ActionBase {
   DECLARE_ACTION_NAME(setrsc);
 
 public:
-  SetRsc(std::string&& value);
-  SetRsc(std::unique_ptr<Macro::MacroBase>&& macro);
+  SetRsc(ActionBase::Branch branch, std::string&& value);
+  SetRsc(ActionBase::Branch branch, std::unique_ptr<Macro::MacroBase>&& macro);
 
 public:
   void evaluate(Transaction& t) const override;
+
+public:
+  const std::string& value() const { return value_; }
 
 private:
   std::string value_;

--- a/src/action/set_sid.cc
+++ b/src/action/set_sid.cc
@@ -22,9 +22,11 @@
 
 namespace Wge {
 namespace Action {
-SetSid::SetSid(std::string&& value) : value_(std::move(value)) {}
+SetSid::SetSid(ActionBase::Branch branch, std::string&& value)
+    : ActionBase(branch), value_(std::move(value)) {}
 
-SetSid::SetSid(std::unique_ptr<Macro::MacroBase>&& macro) : macro_(std::move(macro)) {}
+SetSid::SetSid(ActionBase::Branch branch, std::unique_ptr<Macro::MacroBase>&& macro)
+    : ActionBase(branch), macro_(std::move(macro)) {}
 
 void SetSid::evaluate(Transaction& t) const { throw "Not implemented!"; }
 } // namespace Action

--- a/src/action/set_sid.h
+++ b/src/action/set_sid.h
@@ -37,11 +37,14 @@ class SetSid final : public ActionBase {
   DECLARE_ACTION_NAME(setsid);
 
 public:
-  SetSid(std::string&& value);
-  SetSid(std::unique_ptr<Macro::MacroBase>&& macro);
+  SetSid(ActionBase::Branch branch, std::string&& value);
+  SetSid(ActionBase::Branch branch, std::unique_ptr<Macro::MacroBase>&& macro);
 
 public:
   void evaluate(Transaction& t) const override;
+
+public:
+  const std::string& value() const { return value_; }
 
 private:
   std::string value_;

--- a/src/action/set_uid.cc
+++ b/src/action/set_uid.cc
@@ -22,9 +22,11 @@
 
 namespace Wge {
 namespace Action {
-SetUid::SetUid(std::string&& value) : value_(std::move(value)) {}
+SetUid::SetUid(ActionBase::Branch branch, std::string&& value)
+    : ActionBase(branch), value_(std::move(value)) {}
 
-SetUid::SetUid(std::unique_ptr<Macro::MacroBase>&& macro) : macro_(std::move(macro)) {}
+SetUid::SetUid(ActionBase::Branch branch, std::unique_ptr<Macro::MacroBase>&& macro)
+    : ActionBase(branch), macro_(std::move(macro)) {}
 
 void SetUid::evaluate(Transaction& t) const { throw "Not implemented!"; }
 } // namespace Action

--- a/src/action/set_uid.h
+++ b/src/action/set_uid.h
@@ -37,11 +37,14 @@ class SetUid final : public ActionBase {
   DECLARE_ACTION_NAME(setuid);
 
 public:
-  SetUid(std::string&& value);
-  SetUid(std::unique_ptr<Macro::MacroBase>&& macro);
+  SetUid(ActionBase::Branch branch, std::string&& value);
+  SetUid(ActionBase::Branch branch, std::unique_ptr<Macro::MacroBase>&& macro);
 
 public:
   void evaluate(Transaction& t) const override;
+
+public:
+  const std::string& value() const { return value_; }
 
 private:
   std::string value_;

--- a/src/action/set_var.cc
+++ b/src/action/set_var.cc
@@ -25,9 +25,10 @@
 
 namespace Wge {
 namespace Action {
-SetVar::SetVar(const std::string& ns, std::string&& key, size_t index, Common::Variant&& value,
-               EvaluateType type)
-    : namespace_(ns), key_(std::move(key)), index_(index), value_(std::move(value)), type_(type) {
+SetVar::SetVar(ActionBase::Branch branch, const std::string& ns, std::string&& key, size_t index,
+               Common::Variant&& value, EvaluateType type)
+    : ActionBase(branch), namespace_(ns), key_(std::move(key)), index_(index),
+      value_(std::move(value)), type_(type) {
   // Holds the string value of the variant
   if (IS_STRING_VIEW_VARIANT(value_)) {
     const_cast<std::string&>(value_buffer_) = std::get<std::string_view>(value_);
@@ -35,9 +36,20 @@ SetVar::SetVar(const std::string& ns, std::string&& key, size_t index, Common::V
   }
 }
 
-SetVar::SetVar(const std::string& ns, std::string&& key, size_t index,
+SetVar::SetVar(ActionBase::Branch branch, const std::string& ns, std::string&& key, size_t index,
                std::unique_ptr<Macro::MacroBase>&& value, EvaluateType type)
-    : namespace_(ns), key_(std::move(key)), index_(index), value_macro_(std::move(value)),
+    : ActionBase(branch), namespace_(ns), key_(std::move(key)), index_(index),
+      value_macro_(std::move(value)), type_(type) {
+  // Holds the string value of the variant
+  if (IS_STRING_VIEW_VARIANT(value_)) {
+    const_cast<std::string&>(value_buffer_) = std::get<std::string_view>(value_);
+    const_cast<Common::Variant&>(value_) = value_buffer_;
+  }
+}
+
+SetVar::SetVar(ActionBase::Branch branch, const std::string& ns,
+               std::unique_ptr<Macro::MacroBase>&& key, Common::Variant&& value, EvaluateType type)
+    : ActionBase(branch), namespace_(ns), key_macro_(std::move(key)), value_(std::move(value)),
       type_(type) {
   // Holds the string value of the variant
   if (IS_STRING_VIEW_VARIANT(value_)) {
@@ -46,19 +58,11 @@ SetVar::SetVar(const std::string& ns, std::string&& key, size_t index,
   }
 }
 
-SetVar::SetVar(const std::string& ns, std::unique_ptr<Macro::MacroBase>&& key,
-               Common::Variant&& value, EvaluateType type)
-    : namespace_(ns), key_macro_(std::move(key)), value_(std::move(value)), type_(type) {
-  // Holds the string value of the variant
-  if (IS_STRING_VIEW_VARIANT(value_)) {
-    const_cast<std::string&>(value_buffer_) = std::get<std::string_view>(value_);
-    const_cast<Common::Variant&>(value_) = value_buffer_;
-  }
-}
-
-SetVar::SetVar(const std::string& ns, std::unique_ptr<Macro::MacroBase>&& key,
-               std::unique_ptr<Macro::MacroBase>&& value, EvaluateType type)
-    : namespace_(ns), key_macro_(std::move(key)), value_macro_(std::move(value)), type_(type) {
+SetVar::SetVar(ActionBase::Branch branch, const std::string& ns,
+               std::unique_ptr<Macro::MacroBase>&& key, std::unique_ptr<Macro::MacroBase>&& value,
+               EvaluateType type)
+    : ActionBase(branch), namespace_(ns), key_macro_(std::move(key)),
+      value_macro_(std::move(value)), type_(type) {
   // Holds the string value of the variant
   if (IS_STRING_VIEW_VARIANT(value_)) {
     const_cast<std::string&>(value_buffer_) = std::get<std::string_view>(value_);

--- a/src/action/set_var.h
+++ b/src/action/set_var.h
@@ -49,13 +49,13 @@ public:
   enum class EvaluateType { Create, CreateAndInit, Remove, Increase, Decrease };
 
 public:
-  SetVar(const std::string& ns, std::string&& key, size_t index, Common::Variant&& value,
-         EvaluateType type);
-  SetVar(const std::string& ns, std::string&& key, size_t index,
+  SetVar(ActionBase::Branch branch, const std::string& ns, std::string&& key, size_t index,
+         Common::Variant&& value, EvaluateType type);
+  SetVar(ActionBase::Branch branch, const std::string& ns, std::string&& key, size_t index,
          std::unique_ptr<Macro::MacroBase>&& value, EvaluateType type);
-  SetVar(const std::string& ns, std::unique_ptr<Macro::MacroBase>&& key, Common::Variant&& value,
-         EvaluateType type);
-  SetVar(const std::string& ns, std::unique_ptr<Macro::MacroBase>&& key,
+  SetVar(ActionBase::Branch branch, const std::string& ns, std::unique_ptr<Macro::MacroBase>&& key,
+         Common::Variant&& value, EvaluateType type);
+  SetVar(ActionBase::Branch branch, const std::string& ns, std::unique_ptr<Macro::MacroBase>&& key,
          std::unique_ptr<Macro::MacroBase>&& value, EvaluateType type);
 
 public:

--- a/src/antlr4/SecLangLexer.g4
+++ b/src/antlr4/SecLangLexer.g4
@@ -39,7 +39,8 @@ tokens{
 	INT_RANGE,
 	OPTION,
 	STRING,
-	VAR_COUNT
+	VAR_COUNT,
+	UNMATCHED
 }
 
 QUOTE: '"';
@@ -607,7 +608,8 @@ ModeSecRuleOperatorValue_QUOTE:
 	QUOTE -> type(QUOTE), popMode, popMode, popMode, pushMode(ModeSecRuleAction);
 ModeSecRuleOperatorValue_STRING: (
 		'\\"'
-		| ('|' { [&](){
+		| (
+			'|' { [&](){
 			// Allow | if not followed by @<valid_operator>
 			if (_input->LA(1) != '@') return true;
 			
@@ -630,7 +632,8 @@ ModeSecRuleOperatorValue_STRING: (
 			
 			// Don't match | if it's followed by a valid operator
 			return operators.find(lookahead) == operators.end();
-		}()}?)
+		}()}?
+		)
 		| ~["%|]
 		| ('%' ~[{\\])
 		| ('%\\' .)
@@ -655,6 +658,8 @@ ModeSecRuleActionName_COMMA: COMMA -> type(COMMA);
 ModeSecRuleActionName_SINGLE_QUOTE:
 	SINGLE_QUOTE -> type(SINGLE_QUOTE), pushMode(ModeSecRuleActionString);
 ModeSecRuleActionName_INT: INT -> type(INT);
+ModeSecRuleActionName_UNMATCHED: NOT -> type(UNMATCHED);
+ALWAYS: '*';
 LEVEL: [1-9];
 Accuracy: 'accuracy';
 Allow: 'allow';

--- a/src/antlr4/SecLangParser.g4
+++ b/src/antlr4/SecLangParser.g4
@@ -1130,7 +1130,7 @@ action_non_disruptive_setvar:
 	| action_non_disruptive_setvar_increase
 	| action_non_disruptive_setvar_decrease;
 action_non_disruptive_setvar_create:
-	Setvar COLON (
+	(ALWAYS | UNMATCHED)? Setvar COLON (
 		(
 			SINGLE_QUOTE TX DOT action_non_disruptive_setvar_varname SINGLE_QUOTE
 		)
@@ -1145,7 +1145,7 @@ action_non_disruptive_setvar_varname: (
 		)
 	);
 action_non_disruptive_setvar_create_init:
-	Setvar COLON (
+	(ALWAYS | UNMATCHED)? Setvar COLON (
 		(
 			SINGLE_QUOTE TX DOT action_non_disruptive_setvar_varname ASSIGN
 				action_non_disruptive_setvar_create_init_value SINGLE_QUOTE
@@ -1165,14 +1165,14 @@ action_non_disruptive_setvar_create_init_value: (
 		| (LEFT_RAW_FLAG VAR_RAW_VALUE RIGHT_RAW_FLAG)
 	);
 action_non_disruptive_setvar_remove:
-	Setvar COLON (
+	(ALWAYS | UNMATCHED)? Setvar COLON (
 		(
 			SINGLE_QUOTE NOT TX DOT action_non_disruptive_setvar_varname SINGLE_QUOTE
 		)
 		| (NOT TX DOT action_non_disruptive_setvar_varname)
 	);
 action_non_disruptive_setvar_increase:
-	Setvar COLON (
+	(ALWAYS | UNMATCHED)? Setvar COLON (
 		(
 			SINGLE_QUOTE TX DOT action_non_disruptive_setvar_varname ASSIGN PLUS (
 				VAR_VALUE
@@ -1187,7 +1187,7 @@ action_non_disruptive_setvar_increase:
 		)
 	);
 action_non_disruptive_setvar_decrease:
-	Setvar COLON (
+	(ALWAYS | UNMATCHED)? Setvar COLON (
 		(
 			SINGLE_QUOTE TX DOT action_non_disruptive_setvar_varname ASSIGN MINUS (
 				VAR_VALUE
@@ -1203,23 +1203,23 @@ action_non_disruptive_setvar_decrease:
 	);
 
 action_non_disruptive_setenv:
-	Setenv COLON SINGLE_QUOTE VAR_NAME ASSIGN (
+	(ALWAYS | UNMATCHED)? Setenv COLON SINGLE_QUOTE VAR_NAME ASSIGN (
 		VAR_VALUE
 		| ( PER_CENT LEFT_BRACKET variable RIGHT_BRACKET)
 	) SINGLE_QUOTE;
 
 action_non_disruptive_setuid:
-	Setuid COLON (
+	(ALWAYS | UNMATCHED)? Setuid COLON (
 		(SINGLE_QUOTE STRING SINGLE_QUOTE)
 		| ( PER_CENT LEFT_BRACKET variable RIGHT_BRACKET)
 	);
 action_non_disruptive_setrsc:
-	Setrsc COLON (
+	(ALWAYS | UNMATCHED)? Setrsc COLON (
 		(SINGLE_QUOTE STRING SINGLE_QUOTE)
 		| ( PER_CENT LEFT_BRACKET variable RIGHT_BRACKET)
 	);
 action_non_disruptive_setsid:
-	Setsid COLON (
+	(ALWAYS | UNMATCHED)? Setsid COLON (
 		(SINGLE_QUOTE STRING SINGLE_QUOTE)
 		| ( PER_CENT LEFT_BRACKET variable RIGHT_BRACKET)
 	);
@@ -1306,7 +1306,7 @@ action_non_disruptive_t_trim_right: TRIM_RIGHT;
 action_non_disruptive_t_trim: TRIM;
 
 action_non_disruptive_ctl:
-	Ctl COLON (
+	(ALWAYS | UNMATCHED)? Ctl COLON (
 		action_non_disruptive_ctl_audit_engine
 		| action_non_disruptive_ctl_audit_log_parts
 		| action_non_disruptive_ctl_force_request_body_variable
@@ -1362,7 +1362,7 @@ action_non_disruptive_logdata:
 action_non_disruptive_capture: Capture;
 action_non_disruptive_multi_match: MultiMatch;
 action_non_disruptive_initcol:
-	Initcol COLON persistent_storage_collection ASSIGN string_with_macro;
+	(ALWAYS | UNMATCHED)? Initcol COLON persistent_storage_collection ASSIGN string_with_macro;
 persistent_storage_collection:
 	INIT_COL_GLOBAL
 	| INIT_COL_RESOURCE
@@ -1392,7 +1392,7 @@ action_flow:
 	action_flow_chain
 	| action_flow_skip
 	| action_flow_skip_after;
-action_flow_chain: Chain;
+action_flow_chain: (ALWAYS | UNMATCHED)? Chain;
 action_flow_skip: Skip COLON INT;
 action_flow_skip_after: SkipAfter COLON STRING;
 

--- a/src/antlr4/visitor.cc
+++ b/src/antlr4/visitor.cc
@@ -1305,17 +1305,25 @@ std::any Visitor::visitAction_non_disruptive_setvar_create(
     RETURN_ERROR(key_macro.error());
   }
 
-  auto& actions = current_rule_->get()->actions();
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (key_macro.value()) {
-    actions.emplace_back(std::make_unique<Action::SetVar>(
-        parser_->getCurrentNamespace(), std::move(key_macro.value()), Common::Variant(),
+    current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+        branch, parser_->getCurrentNamespace(), std::move(key_macro.value()), Common::Variant(),
         Action::SetVar::EvaluateType::Create));
   } else {
     std::string key = ctx->action_non_disruptive_setvar_varname()->getText();
     size_t index = parser_->getTxVariableIndex(parser_->getCurrentNamespace(), key, true).value();
-    actions.emplace_back(std::make_unique<Action::SetVar>(parser_->getCurrentNamespace(),
-                                                          std::move(key), index, Common::Variant(),
-                                                          Action::SetVar::EvaluateType::Create));
+    current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+        branch, parser_->getCurrentNamespace(), std::move(key), index, Common::Variant(),
+        Action::SetVar::EvaluateType::Create));
   }
 
   return EMPTY_STRING;
@@ -1323,7 +1331,6 @@ std::any Visitor::visitAction_non_disruptive_setvar_create(
 
 std::any Visitor::visitAction_non_disruptive_setvar_create_init(
     Antlr4Gen::SecLangParser::Action_non_disruptive_setvar_create_initContext* ctx) {
-  auto& actions = current_rule_->get()->actions();
   std::expected<std::unique_ptr<Macro::MacroBase>, std::string> key_macro =
       getMacro(ctx->action_non_disruptive_setvar_varname()->getText(),
                ctx->action_non_disruptive_setvar_varname()->variable(),
@@ -1362,26 +1369,35 @@ std::any Visitor::visitAction_non_disruptive_setvar_create_init(
     }
   }
 
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (key_macro.value()) {
     if (value_macro.value()) {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key_macro.value()),
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key_macro.value()),
           std::move(value_macro.value()), Action::SetVar::EvaluateType::CreateAndInit));
     } else {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key_macro.value()), std::move(value_variant),
-          Action::SetVar::EvaluateType::CreateAndInit));
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key_macro.value()),
+          std::move(value_variant), Action::SetVar::EvaluateType::CreateAndInit));
     }
   } else {
     std::string key = ctx->action_non_disruptive_setvar_varname()->getText();
     size_t index = parser_->getTxVariableIndex(parser_->getCurrentNamespace(), key, true).value();
     if (value_macro.value()) {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key), index, std::move(value_macro.value()),
-          Action::SetVar::EvaluateType::CreateAndInit));
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key), index,
+          std::move(value_macro.value()), Action::SetVar::EvaluateType::CreateAndInit));
     } else {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key), index, std::move(value_variant),
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key), index, std::move(value_variant),
           Action::SetVar::EvaluateType::CreateAndInit));
     }
   }
@@ -1400,17 +1416,25 @@ std::any Visitor::visitAction_non_disruptive_setvar_remove(
     RETURN_ERROR(key_macro.error());
   }
 
-  auto& actions = current_rule_->get()->actions();
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (key_macro.value()) {
-    actions.emplace_back(std::make_unique<Action::SetVar>(
-        parser_->getCurrentNamespace(), std::move(key_macro.value()), Common::Variant(),
+    current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+        branch, parser_->getCurrentNamespace(), std::move(key_macro.value()), Common::Variant(),
         Action::SetVar::EvaluateType::Remove));
   } else {
     std::string key = ctx->action_non_disruptive_setvar_varname()->getText();
     size_t index = parser_->getTxVariableIndex(parser_->getCurrentNamespace(), key, true).value();
-    actions.emplace_back(std::make_unique<Action::SetVar>(parser_->getCurrentNamespace(),
-                                                          std::move(key), index, Common::Variant(),
-                                                          Action::SetVar::EvaluateType::Remove));
+    current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+        branch, parser_->getCurrentNamespace(), std::move(key), index, Common::Variant(),
+        Action::SetVar::EvaluateType::Remove));
   }
 
   return EMPTY_STRING;
@@ -1418,7 +1442,6 @@ std::any Visitor::visitAction_non_disruptive_setvar_remove(
 
 std::any Visitor::visitAction_non_disruptive_setvar_increase(
     Antlr4Gen::SecLangParser::Action_non_disruptive_setvar_increaseContext* ctx) {
-  auto& actions = current_rule_->get()->actions();
   std::expected<std::unique_ptr<Macro::MacroBase>, std::string> key_macro =
       getMacro(ctx->action_non_disruptive_setvar_varname()->getText(),
                ctx->action_non_disruptive_setvar_varname()->variable(),
@@ -1448,26 +1471,35 @@ std::any Visitor::visitAction_non_disruptive_setvar_increase(
     }
   }
 
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (key_macro.value()) {
     if (value_macro.value()) {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key_macro.value()),
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key_macro.value()),
           std::move(value_macro.value()), Action::SetVar::EvaluateType::Increase));
     } else {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key_macro.value()), std::move(value_variant),
-          Action::SetVar::EvaluateType::Increase));
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key_macro.value()),
+          std::move(value_variant), Action::SetVar::EvaluateType::Increase));
     }
   } else {
     std::string key = ctx->action_non_disruptive_setvar_varname()->getText();
     size_t index = parser_->getTxVariableIndex(parser_->getCurrentNamespace(), key, true).value();
     if (value_macro.value()) {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key), index, std::move(value_macro.value()),
-          Action::SetVar::EvaluateType::Increase));
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key), index,
+          std::move(value_macro.value()), Action::SetVar::EvaluateType::Increase));
     } else {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key), index, std::move(value_variant),
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key), index, std::move(value_variant),
           Action::SetVar::EvaluateType::Increase));
     }
   }
@@ -1477,7 +1509,6 @@ std::any Visitor::visitAction_non_disruptive_setvar_increase(
 
 std::any Visitor::visitAction_non_disruptive_setvar_decrease(
     Antlr4Gen::SecLangParser::Action_non_disruptive_setvar_decreaseContext* ctx) {
-  auto& actions = current_rule_->get()->actions();
   std::expected<std::unique_ptr<Macro::MacroBase>, std::string> key_macro =
       getMacro(ctx->action_non_disruptive_setvar_varname()->getText(),
                ctx->action_non_disruptive_setvar_varname()->variable(),
@@ -1507,26 +1538,35 @@ std::any Visitor::visitAction_non_disruptive_setvar_decrease(
     }
   }
 
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (key_macro.value()) {
     if (value_macro.value()) {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key_macro.value()),
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key_macro.value()),
           std::move(value_macro.value()), Action::SetVar::EvaluateType::Decrease));
     } else {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key_macro.value()), std::move(value_variant),
-          Action::SetVar::EvaluateType::Decrease));
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key_macro.value()),
+          std::move(value_variant), Action::SetVar::EvaluateType::Decrease));
     }
   } else {
     std::string key = ctx->action_non_disruptive_setvar_varname()->getText();
     size_t index = parser_->getTxVariableIndex(parser_->getCurrentNamespace(), key, true).value();
     if (value_macro.value()) {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key), index, std::move(value_macro.value()),
-          Action::SetVar::EvaluateType::Decrease));
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key), index,
+          std::move(value_macro.value()), Action::SetVar::EvaluateType::Decrease));
     } else {
-      actions.emplace_back(std::make_unique<Action::SetVar>(
-          parser_->getCurrentNamespace(), std::move(key), index, std::move(value_variant),
+      current_rule_->get()->appendAction(std::make_unique<Action::SetVar>(
+          branch, parser_->getCurrentNamespace(), std::move(key), index, std::move(value_variant),
           Action::SetVar::EvaluateType::Decrease));
     }
   }
@@ -1543,13 +1583,21 @@ std::any Visitor::visitAction_non_disruptive_setenv(
     RETURN_ERROR(value_macro.error());
   }
 
-  auto& actions = current_rule_->get()->actions();
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (value_macro.value()) {
-    actions.emplace_back(std::make_unique<Action::SetEnv>(ctx->VAR_NAME()->getText(),
-                                                          std::move(value_macro.value())));
+    current_rule_->get()->appendAction(std::make_unique<Action::SetEnv>(
+        branch, ctx->VAR_NAME()->getText(), std::move(value_macro.value())));
   } else {
-    actions.emplace_back(
-        std::make_unique<Action::SetEnv>(ctx->VAR_NAME()->getText(), ctx->VAR_VALUE()->getText()));
+    current_rule_->get()->appendAction(std::make_unique<Action::SetEnv>(
+        branch, ctx->VAR_NAME()->getText(), ctx->VAR_VALUE()->getText()));
   }
 
   return EMPTY_STRING;
@@ -1564,11 +1612,21 @@ std::any Visitor::visitAction_non_disruptive_setuid(
     RETURN_ERROR(value_macro.error());
   }
 
-  auto& actions = current_rule_->get()->actions();
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (value_macro.value()) {
-    actions.emplace_back(std::make_unique<Action::SetUid>(std::move(value_macro.value())));
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::SetUid>(branch, std::move(value_macro.value())));
   } else {
-    actions.emplace_back(std::make_unique<Action::SetUid>(ctx->STRING()->getText()));
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::SetUid>(branch, ctx->STRING()->getText()));
   }
 
   return EMPTY_STRING;
@@ -1583,11 +1641,21 @@ std::any Visitor::visitAction_non_disruptive_setrsc(
     RETURN_ERROR(value_macro.error());
   }
 
-  auto& actions = current_rule_->get()->actions();
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (value_macro.value()) {
-    actions.emplace_back(std::make_unique<Action::SetRsc>(std::move(value_macro.value())));
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::SetRsc>(branch, std::move(value_macro.value())));
   } else {
-    actions.emplace_back(std::make_unique<Action::SetRsc>(ctx->STRING()->getText()));
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::SetRsc>(branch, ctx->STRING()->getText()));
   }
 
   return EMPTY_STRING;
@@ -1602,11 +1670,21 @@ std::any Visitor::visitAction_non_disruptive_setsid(
     RETURN_ERROR(value_macro.error());
   }
 
-  auto& actions = current_rule_->get()->actions();
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (value_macro.value()) {
-    actions.emplace_back(std::make_unique<Action::SetSid>(std::move(value_macro.value())));
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::SetSid>(branch, std::move(value_macro.value())));
   } else {
-    actions.emplace_back(std::make_unique<Action::SetSid>(ctx->STRING()->getText()));
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::SetSid>(branch, ctx->STRING()->getText()));
   }
 
   return EMPTY_STRING;
@@ -1891,9 +1969,16 @@ std::any Visitor::visitAction_non_disruptive_ctl_audit_engine(
     option = Option::RelevantOnly;
   }
 
-  auto& actions = current_rule_->get()->actions();
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
 
-  actions.emplace_back(std::make_unique<Action::Ctl>(Action::Ctl::CtlType::AuditEngine, option));
+  current_rule_->get()->appendAction(
+      std::make_unique<Action::Ctl>(branch, Action::Ctl::CtlType::AuditEngine, option));
 
   return EMPTY_STRING;
 }
@@ -1902,8 +1987,16 @@ std::any Visitor::visitAction_non_disruptive_ctl_audit_log_parts(
     Antlr4Gen::SecLangParser::Action_non_disruptive_ctl_audit_log_partsContext* ctx) {
   std::string parts = ctx->AUDIT_PARTS()->getText();
 
-  auto& actions = current_rule_->get()->actions();
-  actions.emplace_back(std::make_unique<Action::Ctl>(Action::Ctl::CtlType::AuditLogParts, parts));
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
+  current_rule_->get()->appendAction(
+      std::make_unique<Action::Ctl>(branch, Action::Ctl::CtlType::AuditLogParts, parts));
 
   return EMPTY_STRING;
 }
@@ -1926,9 +2019,16 @@ std::any Visitor::visitAction_non_disruptive_ctl_parse_xml_into_args(
     option = Option::OnlyArgs;
   }
 
-  auto& actions = current_rule_->get()->actions();
-  actions.emplace_back(
-      std::make_unique<Action::Ctl>(Action::Ctl::CtlType::ParseXmlIntoArgs, option));
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
+  current_rule_->get()->appendAction(
+      std::make_unique<Action::Ctl>(branch, Action::Ctl::CtlType::ParseXmlIntoArgs, option));
   return EMPTY_STRING;
 }
 
@@ -1942,69 +2042,121 @@ std::any Visitor::visitAction_non_disruptive_ctl_request_body_access(
     option = Option::On;
   }
 
-  auto& actions = current_rule_->get()->actions();
-  actions.emplace_back(
-      std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RequestBodyAccess, option));
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
+  current_rule_->get()->appendAction(
+      std::make_unique<Action::Ctl>(branch, Action::Ctl::CtlType::RequestBodyAccess, option));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitAction_non_disruptive_ctl_request_body_processor_url_encode(
     Antlr4Gen::SecLangParser::Action_non_disruptive_ctl_request_body_processor_url_encodeContext*
         ctx) {
-  auto& actions = current_rule_->get()->actions();
-  actions.emplace_back(std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RequestBodyProcessor,
-                                                     BodyProcessorType::UrlEncoded));
+
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
+  current_rule_->get()->appendAction(std::make_unique<Action::Ctl>(
+      branch, Action::Ctl::CtlType::RequestBodyProcessor, BodyProcessorType::UrlEncoded));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitAction_non_disruptive_ctl_request_body_processor_multi_part(
     Antlr4Gen::SecLangParser::Action_non_disruptive_ctl_request_body_processor_multi_partContext*
         ctx) {
-  auto& actions = current_rule_->get()->actions();
-  actions.emplace_back(std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RequestBodyProcessor,
-                                                     BodyProcessorType::MultiPart));
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
+  current_rule_->get()->appendAction(std::make_unique<Action::Ctl>(
+      branch, Action::Ctl::CtlType::RequestBodyProcessor, BodyProcessorType::MultiPart));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitAction_non_disruptive_ctl_request_body_processor_xml(
     Antlr4Gen::SecLangParser::Action_non_disruptive_ctl_request_body_processor_xmlContext* ctx) {
-  auto& actions = current_rule_->get()->actions();
-  actions.emplace_back(std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RequestBodyProcessor,
-                                                     BodyProcessorType::Xml));
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
+  current_rule_->get()->appendAction(std::make_unique<Action::Ctl>(
+      branch, Action::Ctl::CtlType::RequestBodyProcessor, BodyProcessorType::Xml));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitAction_non_disruptive_ctl_request_body_processor_json(
     Antlr4Gen::SecLangParser::Action_non_disruptive_ctl_request_body_processor_jsonContext* ctx) {
-  auto& actions = current_rule_->get()->actions();
-  actions.emplace_back(std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RequestBodyProcessor,
-                                                     BodyProcessorType::Json));
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
+  current_rule_->get()->appendAction(std::make_unique<Action::Ctl>(
+      branch, Action::Ctl::CtlType::RequestBodyProcessor, BodyProcessorType::Json));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitAction_non_disruptive_ctl_rule_engine(
     Antlr4Gen::SecLangParser::Action_non_disruptive_ctl_rule_engineContext* ctx) {
   Wge::EngineConfig::Option option = optionStr2EnumValue(ctx->OPTION()->getText());
-  auto& actions = current_rule_->get()->actions();
-  actions.emplace_back(std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RuleEngine, option));
+
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
+  current_rule_->get()->appendAction(
+      std::make_unique<Action::Ctl>(branch, Action::Ctl::CtlType::RuleEngine, option));
   return EMPTY_STRING;
 }
 
 std::any Visitor::visitAction_non_disruptive_ctl_rule_remove_by_id(
     Antlr4Gen::SecLangParser::Action_non_disruptive_ctl_rule_remove_by_idContext* ctx) {
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (ctx->INT()) {
     uint64_t id = ::atoll(ctx->INT()->getText().c_str());
-    auto& actions = current_rule_->get()->actions();
-    actions.emplace_back(std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RuleRemoveById, id));
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::Ctl>(branch, Action::Ctl::CtlType::RuleRemoveById, id));
   } else {
     std::string id_range_str = ctx->INT_RANGE()->getText();
     auto pos = id_range_str.find('-');
     if (pos != std::string::npos) {
       uint64_t first = ::atoll(id_range_str.substr(0, pos).c_str());
       uint64_t last = ::atoll(id_range_str.substr(pos + 1).c_str());
-      auto& actions = current_rule_->get()->actions();
-      actions.emplace_back(std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RuleRemoveByIdRange,
-                                                         std::make_pair(first, last)));
+      current_rule_->get()->appendAction(std::make_unique<Action::Ctl>(
+          branch, Action::Ctl::CtlType::RuleRemoveByIdRange, std::make_pair(first, last)));
     }
   }
 
@@ -2014,9 +2166,17 @@ std::any Visitor::visitAction_non_disruptive_ctl_rule_remove_by_id(
 std::any Visitor::visitAction_non_disruptive_ctl_rule_remove_by_tag(
     Antlr4Gen::SecLangParser::Action_non_disruptive_ctl_rule_remove_by_tagContext* ctx) {
   std::string tag = ctx->STRING()->getText();
-  auto& actions = current_rule_->get()->actions();
-  actions.emplace_back(
-      std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RuleRemoveByTag, std::move(tag)));
+
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  auto* parent_ctx =
+      dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+  if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+    branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                  : Action::ActionBase::Branch::Unmatched;
+  }
+
+  current_rule_->get()->appendAction(
+      std::make_unique<Action::Ctl>(branch, Action::Ctl::CtlType::RuleRemoveByTag, std::move(tag)));
   return EMPTY_STRING;
 }
 
@@ -2038,9 +2198,16 @@ std::any Visitor::visitAction_non_disruptive_ctl_rule_remove_target_by_id(
       variable_objects.emplace_back(var_obj);
     }
 
-    auto& actions = current_rule_->get()->actions();
-    actions.emplace_back(
-        std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RuleRemoveTargetById,
+    Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+    auto* parent_ctx =
+        dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+    if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+      branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                    : Action::ActionBase::Branch::Unmatched;
+    }
+
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::Ctl>(branch, Action::Ctl::CtlType::RuleRemoveTargetById,
                                       std::make_pair(id, std::move(variable_objects))));
   } catch (const std::bad_any_cast& ex) {
     assert(false);
@@ -2071,9 +2238,16 @@ std::any Visitor::visitAction_non_disruptive_ctl_rule_remove_target_by_tag(
       variable_objects.emplace_back(var_obj);
     }
 
-    auto& actions = current_rule_->get()->actions();
-    actions.emplace_back(
-        std::make_unique<Action::Ctl>(Action::Ctl::CtlType::RuleRemoveTargetByTag,
+    Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+    auto* parent_ctx =
+        dynamic_cast<Antlr4Gen::SecLangParser::Action_non_disruptive_ctlContext*>(ctx->parent);
+    if (parent_ctx && (parent_ctx->ALWAYS() || parent_ctx->UNMATCHED())) {
+      branch = parent_ctx->ALWAYS() ? Action::ActionBase::Branch::Always
+                                    : Action::ActionBase::Branch::Unmatched;
+    }
+
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::Ctl>(branch, Action::Ctl::CtlType::RuleRemoveTargetByTag,
                                       std::make_pair(std::move(tag), std::move(variable_objects))));
   } catch (const std::bad_any_cast& ex) {
     current_rule_->visitVariableMode(old_visit_variable_mode);
@@ -2167,13 +2341,21 @@ std::any Visitor::visitAction_non_disruptive_initcol(
     RETURN_ERROR(macro.error());
   }
 
-  auto& actions = current_rule_->get()->actions();
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
   if (macro.value()) {
-    actions.emplace_back(
-        std::make_unique<Action::InitCol>(type, std::move(name), std::move(macro.value())));
+    current_rule_->get()->appendAction(
+        std::make_unique<Action::InitCol>(branch, type, std::move(name), std::move(macro.value())));
   } else {
-    actions.emplace_back(std::make_unique<Action::InitCol>(type, std::move(name),
-                                                           ctx->string_with_macro()->getText()));
+    current_rule_->get()->appendAction(std::make_unique<Action::InitCol>(
+        branch, type, std::move(name), ctx->string_with_macro()->getText()));
   }
 
   return EMPTY_STRING;
@@ -2237,6 +2419,31 @@ Visitor::visitAction_data_xml_ns(Antlr4Gen::SecLangParser::Action_data_xml_nsCon
 
 std::any Visitor::visitAction_flow_chain(Antlr4Gen::SecLangParser::Action_flow_chainContext* ctx) {
   chain_ = true;
+
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
+  switch (branch) {
+  case Action::ActionBase::Branch::Matched:
+    current_rule_->get()->matchedChain(true);
+    break;
+  case Action::ActionBase::Branch::Unmatched:
+    current_rule_->get()->unmatchedChain(true);
+    break;
+  case Action::ActionBase::Branch::Always:
+    current_rule_->get()->matchedChain(true);
+    current_rule_->get()->unmatchedChain(true);
+    break;
+  default:
+    break;
+  }
+
   return EMPTY_STRING;
 }
 

--- a/test/parser/rule_action_parse_test.cc
+++ b/test/parser/rule_action_parse_test.cc
@@ -57,15 +57,49 @@ TEST_F(RuleActionParseTest, NoAction) {
 
 TEST_F(RuleActionParseTest, ActionSetVar) {
   const std::string rule_directive =
-      R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setvar:'tx.score',msg:'aaa'")";
+      R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setvar:'tx.score0',!setvar:'tx.score1',*setvar:'tx.score2', msg:'aaa'")";
 
   Antlr4::Parser parser;
   auto result = parser.load(rule_directive);
   ASSERT_TRUE(result.has_value());
 
-  auto& actions = parser.rules()[0].back().actions();
-  EXPECT_EQ(actions.size(), 1);
-  EXPECT_EQ(std::string_view(actions.back()->name()), "setvar");
+  auto& all_actions = parser.rules()[0].back().actions();
+  auto& matched_branch_actions = parser.rules()[0].back().matchedBranchActions();
+  auto& unmatched_branch_actions = parser.rules()[0].back().unmatchedBranchActions();
+  ASSERT_EQ(all_actions.size(), 3);
+  ASSERT_EQ(matched_branch_actions.size(), 2);
+  ASSERT_EQ(unmatched_branch_actions.size(), 2);
+
+  const Action::SetVar* all_action0 = dynamic_cast<const Action::SetVar*>(all_actions[0].get());
+  const Action::SetVar* all_action1 = dynamic_cast<const Action::SetVar*>(all_actions[1].get());
+  const Action::SetVar* all_action2 = dynamic_cast<const Action::SetVar*>(all_actions[2].get());
+  const Action::SetVar* matched_action0 =
+      dynamic_cast<const Action::SetVar*>(matched_branch_actions[0]);
+  const Action::SetVar* matched_action1 =
+      dynamic_cast<const Action::SetVar*>(matched_branch_actions[1]);
+  const Action::SetVar* unmatched_action0 =
+      dynamic_cast<const Action::SetVar*>(unmatched_branch_actions[0]);
+  const Action::SetVar* unmatched_action1 =
+      dynamic_cast<const Action::SetVar*>(unmatched_branch_actions[1]);
+  ASSERT_NE(all_action0, nullptr);
+  ASSERT_NE(all_action1, nullptr);
+  ASSERT_NE(all_action2, nullptr);
+  ASSERT_NE(matched_action0, nullptr);
+  ASSERT_NE(matched_action1, nullptr);
+  ASSERT_NE(unmatched_action0, nullptr);
+  ASSERT_NE(unmatched_action1, nullptr);
+
+  EXPECT_EQ(all_action0, matched_action0);
+  EXPECT_EQ(all_action1, unmatched_action0);
+  EXPECT_EQ(all_action2, matched_action1);
+  EXPECT_EQ(all_action2, unmatched_action1);
+
+  EXPECT_EQ(std::string_view(all_actions[0]->name()), "setvar");
+  EXPECT_EQ(std::string_view(all_actions[1]->name()), "setvar");
+  EXPECT_EQ(std::string_view(all_actions[2]->name()), "setvar");
+  EXPECT_EQ(all_action0->key(), "score0");
+  EXPECT_EQ(all_action1->key(), "score1");
+  EXPECT_EQ(all_action2->key(), "score2");
 }
 
 TEST_F(RuleActionParseTest, ActionSetVarWithNoSigleQuote) {
@@ -83,29 +117,97 @@ TEST_F(RuleActionParseTest, ActionSetVarWithNoSigleQuote) {
 
 TEST_F(RuleActionParseTest, ActionSetEnv) {
   const std::string rule_directive =
-      R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setenv:'var1=hello',msg:'aaa bbb'")";
+      R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setenv:'score0=hello',!setenv:'score1=hello',*setenv:'score2=hello',msg:'aaa bbb'")";
 
   Antlr4::Parser parser;
   auto result = parser.load(rule_directive);
   ASSERT_TRUE(result.has_value());
 
-  auto& actions = parser.rules()[0].back().actions();
-  EXPECT_EQ(actions.size(), 1);
-  EXPECT_EQ(std::string_view(actions.back()->name()), "setenv");
+  auto& all_actions = parser.rules()[0].back().actions();
+  auto& matched_branch_actions = parser.rules()[0].back().matchedBranchActions();
+  auto& unmatched_branch_actions = parser.rules()[0].back().unmatchedBranchActions();
+  ASSERT_EQ(all_actions.size(), 3);
+  ASSERT_EQ(matched_branch_actions.size(), 2);
+  ASSERT_EQ(unmatched_branch_actions.size(), 2);
+
+  const Action::SetEnv* all_action0 = dynamic_cast<const Action::SetEnv*>(all_actions[0].get());
+  const Action::SetEnv* all_action1 = dynamic_cast<const Action::SetEnv*>(all_actions[1].get());
+  const Action::SetEnv* all_action2 = dynamic_cast<const Action::SetEnv*>(all_actions[2].get());
+  const Action::SetEnv* matched_action0 =
+      dynamic_cast<const Action::SetEnv*>(matched_branch_actions[0]);
+  const Action::SetEnv* matched_action1 =
+      dynamic_cast<const Action::SetEnv*>(matched_branch_actions[1]);
+  const Action::SetEnv* unmatched_action0 =
+      dynamic_cast<const Action::SetEnv*>(unmatched_branch_actions[0]);
+  const Action::SetEnv* unmatched_action1 =
+      dynamic_cast<const Action::SetEnv*>(unmatched_branch_actions[1]);
+  ASSERT_NE(all_action0, nullptr);
+  ASSERT_NE(all_action1, nullptr);
+  ASSERT_NE(all_action2, nullptr);
+  ASSERT_NE(matched_action0, nullptr);
+  ASSERT_NE(matched_action1, nullptr);
+  ASSERT_NE(unmatched_action0, nullptr);
+  ASSERT_NE(unmatched_action1, nullptr);
+
+  EXPECT_EQ(all_action0, matched_action0);
+  EXPECT_EQ(all_action1, unmatched_action0);
+  EXPECT_EQ(all_action2, matched_action1);
+  EXPECT_EQ(all_action2, unmatched_action1);
+
+  EXPECT_EQ(std::string_view(all_actions[0]->name()), "setenv");
+  EXPECT_EQ(std::string_view(all_actions[1]->name()), "setenv");
+  EXPECT_EQ(std::string_view(all_actions[2]->name()), "setenv");
+  EXPECT_EQ(all_action0->key(), "score0");
+  EXPECT_EQ(all_action1->key(), "score1");
+  EXPECT_EQ(all_action2->key(), "score2");
 }
 
 TEST_F(RuleActionParseTest, ActionSetRsc) {
   {
     const std::string rule_directive =
-        R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setrsc:'this is rsc',msg:'aaa'")";
+        R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setrsc:'this is rsc0',!setrsc:'this is rsc1',*setrsc:'this is rsc2',msg:'aaa'")";
 
     Antlr4::Parser parser;
     auto result = parser.load(rule_directive);
     ASSERT_TRUE(result.has_value());
-    ASSERT_TRUE(result.has_value());
-    auto& actions = parser.rules()[0].back().actions();
-    EXPECT_EQ(actions.size(), 1);
-    EXPECT_EQ(std::string_view(actions.back()->name()), "setrsc");
+
+    auto& all_actions = parser.rules()[0].back().actions();
+    auto& matched_branch_actions = parser.rules()[0].back().matchedBranchActions();
+    auto& unmatched_branch_actions = parser.rules()[0].back().unmatchedBranchActions();
+    ASSERT_EQ(all_actions.size(), 3);
+    ASSERT_EQ(matched_branch_actions.size(), 2);
+    ASSERT_EQ(unmatched_branch_actions.size(), 2);
+
+    const Action::SetRsc* all_action0 = dynamic_cast<const Action::SetRsc*>(all_actions[0].get());
+    const Action::SetRsc* all_action1 = dynamic_cast<const Action::SetRsc*>(all_actions[1].get());
+    const Action::SetRsc* all_action2 = dynamic_cast<const Action::SetRsc*>(all_actions[2].get());
+    const Action::SetRsc* matched_action0 =
+        dynamic_cast<const Action::SetRsc*>(matched_branch_actions[0]);
+    const Action::SetRsc* matched_action1 =
+        dynamic_cast<const Action::SetRsc*>(matched_branch_actions[1]);
+    const Action::SetRsc* unmatched_action0 =
+        dynamic_cast<const Action::SetRsc*>(unmatched_branch_actions[0]);
+    const Action::SetRsc* unmatched_action1 =
+        dynamic_cast<const Action::SetRsc*>(unmatched_branch_actions[1]);
+    ASSERT_NE(all_action0, nullptr);
+    ASSERT_NE(all_action1, nullptr);
+    ASSERT_NE(all_action2, nullptr);
+    ASSERT_NE(matched_action0, nullptr);
+    ASSERT_NE(matched_action1, nullptr);
+    ASSERT_NE(unmatched_action0, nullptr);
+    ASSERT_NE(unmatched_action1, nullptr);
+
+    EXPECT_EQ(all_action0, matched_action0);
+    EXPECT_EQ(all_action1, unmatched_action0);
+    EXPECT_EQ(all_action2, matched_action1);
+    EXPECT_EQ(all_action2, unmatched_action1);
+
+    EXPECT_EQ(std::string_view(all_actions[0]->name()), "setrsc");
+    EXPECT_EQ(std::string_view(all_actions[1]->name()), "setrsc");
+    EXPECT_EQ(std::string_view(all_actions[2]->name()), "setrsc");
+    EXPECT_EQ(all_action0->value(), "this is rsc0");
+    EXPECT_EQ(all_action1->value(), "this is rsc1");
+    EXPECT_EQ(all_action2->value(), "this is rsc2");
   }
 
   // Macro expansion
@@ -126,13 +228,48 @@ TEST_F(RuleActionParseTest, ActionSetRsc) {
 TEST_F(RuleActionParseTest, ActionSetSid) {
   {
     const std::string rule_directive =
-        R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setsid:'this is sid',msg:'aaa'")";
+        R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setsid:'this is sid0',!setsid:'this is sid1',*setsid:'this is sid2',msg:'aaa'")";
     Antlr4::Parser parser;
     auto result = parser.load(rule_directive);
     ASSERT_TRUE(result.has_value());
-    auto& actions = parser.rules()[0].back().actions();
-    EXPECT_EQ(actions.size(), 1);
-    EXPECT_EQ(std::string_view(actions.back()->name()), "setsid");
+
+    auto& all_actions = parser.rules()[0].back().actions();
+    auto& matched_branch_actions = parser.rules()[0].back().matchedBranchActions();
+    auto& unmatched_branch_actions = parser.rules()[0].back().unmatchedBranchActions();
+    ASSERT_EQ(all_actions.size(), 3);
+    ASSERT_EQ(matched_branch_actions.size(), 2);
+    ASSERT_EQ(unmatched_branch_actions.size(), 2);
+
+    const Action::SetSid* all_action0 = dynamic_cast<const Action::SetSid*>(all_actions[0].get());
+    const Action::SetSid* all_action1 = dynamic_cast<const Action::SetSid*>(all_actions[1].get());
+    const Action::SetSid* all_action2 = dynamic_cast<const Action::SetSid*>(all_actions[2].get());
+    const Action::SetSid* matched_action0 =
+        dynamic_cast<const Action::SetSid*>(matched_branch_actions[0]);
+    const Action::SetSid* matched_action1 =
+        dynamic_cast<const Action::SetSid*>(matched_branch_actions[1]);
+    const Action::SetSid* unmatched_action0 =
+        dynamic_cast<const Action::SetSid*>(unmatched_branch_actions[0]);
+    const Action::SetSid* unmatched_action1 =
+        dynamic_cast<const Action::SetSid*>(unmatched_branch_actions[1]);
+    ASSERT_NE(all_action0, nullptr);
+    ASSERT_NE(all_action1, nullptr);
+    ASSERT_NE(all_action2, nullptr);
+    ASSERT_NE(matched_action0, nullptr);
+    ASSERT_NE(matched_action1, nullptr);
+    ASSERT_NE(unmatched_action0, nullptr);
+    ASSERT_NE(unmatched_action1, nullptr);
+
+    EXPECT_EQ(all_action0, matched_action0);
+    EXPECT_EQ(all_action1, unmatched_action0);
+    EXPECT_EQ(all_action2, matched_action1);
+    EXPECT_EQ(all_action2, unmatched_action1);
+
+    EXPECT_EQ(std::string_view(all_actions[0]->name()), "setsid");
+    EXPECT_EQ(std::string_view(all_actions[1]->name()), "setsid");
+    EXPECT_EQ(std::string_view(all_actions[2]->name()), "setsid");
+    EXPECT_EQ(all_action0->value(), "this is sid0");
+    EXPECT_EQ(all_action1->value(), "this is sid1");
+    EXPECT_EQ(all_action2->value(), "this is sid2");
   }
 
   // Macro expansion
@@ -151,13 +288,48 @@ TEST_F(RuleActionParseTest, ActionSetSid) {
 TEST_F(RuleActionParseTest, ActionSetUid) {
   {
     const std::string rule_directive =
-        R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setuid:'this is uid',msg:'aaa'")";
+        R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,setuid:'this is uid0',!setuid:'this is uid1',*setuid:'this is uid2',msg:'aaa'")";
     Antlr4::Parser parser;
     auto result = parser.load(rule_directive);
     ASSERT_TRUE(result.has_value());
-    auto& actions = parser.rules()[0].back().actions();
-    EXPECT_EQ(actions.size(), 1);
-    EXPECT_EQ(std::string_view(actions.back()->name()), "setuid");
+
+    auto& all_actions = parser.rules()[0].back().actions();
+    auto& matched_branch_actions = parser.rules()[0].back().matchedBranchActions();
+    auto& unmatched_branch_actions = parser.rules()[0].back().unmatchedBranchActions();
+    ASSERT_EQ(all_actions.size(), 3);
+    ASSERT_EQ(matched_branch_actions.size(), 2);
+    ASSERT_EQ(unmatched_branch_actions.size(), 2);
+
+    const Action::SetUid* all_action0 = dynamic_cast<const Action::SetUid*>(all_actions[0].get());
+    const Action::SetUid* all_action1 = dynamic_cast<const Action::SetUid*>(all_actions[1].get());
+    const Action::SetUid* all_action2 = dynamic_cast<const Action::SetUid*>(all_actions[2].get());
+    const Action::SetUid* matched_action0 =
+        dynamic_cast<const Action::SetUid*>(matched_branch_actions[0]);
+    const Action::SetUid* matched_action1 =
+        dynamic_cast<const Action::SetUid*>(matched_branch_actions[1]);
+    const Action::SetUid* unmatched_action0 =
+        dynamic_cast<const Action::SetUid*>(unmatched_branch_actions[0]);
+    const Action::SetUid* unmatched_action1 =
+        dynamic_cast<const Action::SetUid*>(unmatched_branch_actions[1]);
+    ASSERT_NE(all_action0, nullptr);
+    ASSERT_NE(all_action1, nullptr);
+    ASSERT_NE(all_action2, nullptr);
+    ASSERT_NE(matched_action0, nullptr);
+    ASSERT_NE(matched_action1, nullptr);
+    ASSERT_NE(unmatched_action0, nullptr);
+    ASSERT_NE(unmatched_action1, nullptr);
+
+    EXPECT_EQ(all_action0, matched_action0);
+    EXPECT_EQ(all_action1, unmatched_action0);
+    EXPECT_EQ(all_action2, matched_action1);
+    EXPECT_EQ(all_action2, unmatched_action1);
+
+    EXPECT_EQ(std::string_view(all_actions[0]->name()), "setuid");
+    EXPECT_EQ(std::string_view(all_actions[1]->name()), "setuid");
+    EXPECT_EQ(std::string_view(all_actions[2]->name()), "setuid");
+    EXPECT_EQ(all_action0->value(), "this is uid0");
+    EXPECT_EQ(all_action1->value(), "this is uid1");
+    EXPECT_EQ(all_action2->value(), "this is uid2");
   }
 
   // Macro expansion
@@ -321,10 +493,43 @@ TEST_F(RuleActionParseTest, ActionXmlns) {
 
 TEST_F(RuleActionParseTest, ActionCtlAuditEngine) {
   const std::string rule_directive =
-      R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,ctl:auditEngine=On,msg:'aaa'")";
+      R"(SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,ctl:auditEngine=On,!ctl:auditEngine=On,*ctl:auditEngine=On,msg:'aaa'")";
   Antlr4::Parser parser;
   auto result = parser.load(rule_directive);
   ASSERT_TRUE(result.has_value());
+
+  auto& all_actions = parser.rules()[0].back().actions();
+  auto& matched_branch_actions = parser.rules()[0].back().matchedBranchActions();
+  auto& unmatched_branch_actions = parser.rules()[0].back().unmatchedBranchActions();
+  ASSERT_EQ(all_actions.size(), 3);
+  ASSERT_EQ(matched_branch_actions.size(), 2);
+  ASSERT_EQ(unmatched_branch_actions.size(), 2);
+
+  const Action::Ctl* all_action0 = dynamic_cast<const Action::Ctl*>(all_actions[0].get());
+  const Action::Ctl* all_action1 = dynamic_cast<const Action::Ctl*>(all_actions[1].get());
+  const Action::Ctl* all_action2 = dynamic_cast<const Action::Ctl*>(all_actions[2].get());
+  const Action::Ctl* matched_action0 = dynamic_cast<const Action::Ctl*>(matched_branch_actions[0]);
+  const Action::Ctl* matched_action1 = dynamic_cast<const Action::Ctl*>(matched_branch_actions[1]);
+  const Action::Ctl* unmatched_action0 =
+      dynamic_cast<const Action::Ctl*>(unmatched_branch_actions[0]);
+  const Action::Ctl* unmatched_action1 =
+      dynamic_cast<const Action::Ctl*>(unmatched_branch_actions[1]);
+  ASSERT_NE(all_action0, nullptr);
+  ASSERT_NE(all_action1, nullptr);
+  ASSERT_NE(all_action2, nullptr);
+  ASSERT_NE(matched_action0, nullptr);
+  ASSERT_NE(matched_action1, nullptr);
+  ASSERT_NE(unmatched_action0, nullptr);
+  ASSERT_NE(unmatched_action1, nullptr);
+
+  EXPECT_EQ(all_action0, matched_action0);
+  EXPECT_EQ(all_action1, unmatched_action0);
+  EXPECT_EQ(all_action2, matched_action1);
+  EXPECT_EQ(all_action2, unmatched_action1);
+
+  EXPECT_EQ(std::string_view(all_actions[0]->name()), "ctl");
+  EXPECT_EQ(std::string_view(all_actions[1]->name()), "ctl");
+  EXPECT_EQ(std::string_view(all_actions[2]->name()), "ctl");
 
   {
     const std::string rule_directive =
@@ -578,6 +783,50 @@ TEST_F(RuleActionParseTest, ActionInitCol) {
   auto& actions = parser.rules()[0].back().actions();
   EXPECT_EQ(actions.size(), 2);
   EXPECT_NE(nullptr, dynamic_cast<Action::InitCol*>(actions.front().get()));
+
+  {
+    const std::string rule_directive =
+        R"(SecRule ARGS:aaa|ARGS:bbb "foo" "id:1,phase:1,initcol:ip=%{remote_addr}_%{MATCHED_VAR},!initcol:ip=%{remote_addr}_%{MATCHED_VAR},*initcol:ip=%{remote_addr}_%{MATCHED_VAR}")";
+
+    Antlr4::Parser parser;
+    auto result = parser.load(rule_directive);
+    ASSERT_TRUE(result.has_value());
+
+    auto& all_actions = parser.rules()[0].back().actions();
+    auto& matched_branch_actions = parser.rules()[0].back().matchedBranchActions();
+    auto& unmatched_branch_actions = parser.rules()[0].back().unmatchedBranchActions();
+    ASSERT_EQ(all_actions.size(), 3);
+    ASSERT_EQ(matched_branch_actions.size(), 2);
+    ASSERT_EQ(unmatched_branch_actions.size(), 2);
+
+    const Action::InitCol* all_action0 = dynamic_cast<const Action::InitCol*>(all_actions[0].get());
+    const Action::InitCol* all_action1 = dynamic_cast<const Action::InitCol*>(all_actions[1].get());
+    const Action::InitCol* all_action2 = dynamic_cast<const Action::InitCol*>(all_actions[2].get());
+    const Action::InitCol* matched_action0 =
+        dynamic_cast<const Action::InitCol*>(matched_branch_actions[0]);
+    const Action::InitCol* matched_action1 =
+        dynamic_cast<const Action::InitCol*>(matched_branch_actions[1]);
+    const Action::InitCol* unmatched_action0 =
+        dynamic_cast<const Action::InitCol*>(unmatched_branch_actions[0]);
+    const Action::InitCol* unmatched_action1 =
+        dynamic_cast<const Action::InitCol*>(unmatched_branch_actions[1]);
+    ASSERT_NE(all_action0, nullptr);
+    ASSERT_NE(all_action1, nullptr);
+    ASSERT_NE(all_action2, nullptr);
+    ASSERT_NE(matched_action0, nullptr);
+    ASSERT_NE(matched_action1, nullptr);
+    ASSERT_NE(unmatched_action0, nullptr);
+    ASSERT_NE(unmatched_action1, nullptr);
+
+    EXPECT_EQ(all_action0, matched_action0);
+    EXPECT_EQ(all_action1, unmatched_action0);
+    EXPECT_EQ(all_action2, matched_action1);
+    EXPECT_EQ(all_action2, unmatched_action1);
+
+    EXPECT_EQ(std::string_view(all_actions[0]->name()), "initcol");
+    EXPECT_EQ(std::string_view(all_actions[1]->name()), "initcol");
+    EXPECT_EQ(std::string_view(all_actions[2]->name()), "initcol");
+  }
 }
 
 TEST_F(RuleActionParseTest, ActionSkipAfter) {


### PR DESCRIPTION
The original implementation only evaluated actions when a rule matched. This commit introduces support for evaluating actions even when a rule does not match. Actions can now be categorized into 'matched' and 'unmatched' branches.
And the chained rules are evaluated based on whether the parent rule matched or not, controlled by `!chain` or `*chain` actions.