### PR TITLE
feat(antlr4,rule): add multiChain action

### DIFF
--- a/src/antlr4/SecLangLexer.g4
+++ b/src/antlr4/SecLangLexer.g4
@@ -490,8 +490,8 @@ ModeSecRuleVariableName_RIGHT_BRACKET:
 mode ModeSecRuleVariableNamePtree;
 ModeSecRuleVariableNamePtree_WS: WS -> skip, popMode, popMode;
 PARENT1:
-	'../' { _input->LA(1) != ' ' && _input->LA(1) != '|' && _input->LA(1) != '}' && _input->LA(1) != '.' }? -> type (PARENT)
-		, pushMode(ModeSecRuleVariableSubNamePtree);
+	'../' { _input->LA(1) != ' ' && _input->LA(1) != '|' && _input->LA(1) != '}' && _input->LA(1) != '.' 
+		}? -> type (PARENT), pushMode(ModeSecRuleVariableSubNamePtree);
 PARENT2: '../' -> type(PARENT);
 ModeSecRuleVariableNamePtree_COLON:
 	COLON -> type(COLON), pushMode(ModeSecRuleVariableSubNamePtree);
@@ -714,6 +714,7 @@ Xmlns: 'xmlns' -> pushMode(ModeSecRuleActionRedirect);
 // Extensions:
 FirstMatch: 'firstMatch';
 EmptyMatch: 'emptyMatch';
+MultiChain: 'multiChain';
 
 mode ModeSecRuleActionSetVar;
 ModeSecRuleActionSetVar_WS: WS -> skip;

--- a/src/antlr4/SecLangParser.g4
+++ b/src/antlr4/SecLangParser.g4
@@ -1415,9 +1415,11 @@ action_flow_skip_after: SkipAfter COLON STRING;
 
 action_extension:
 	action_extension_first_match
-	| action_extension_empty_match;
+	| action_extension_empty_match
+	| action_extension_multi_chain;
 action_extension_first_match: FirstMatch;
 action_extension_empty_match: EmptyMatch;
+action_extension_multi_chain: (ALWAYS | UNMATCHED)? MultiChain;
 
 audit_log_config:
 	sec_audit_engine

--- a/src/antlr4/visitor.cc
+++ b/src/antlr4/visitor.cc
@@ -2480,6 +2480,37 @@ std::any Visitor::visitAction_extension_empty_match(
   return EMPTY_STRING;
 }
 
+std::any Visitor::visitAction_extension_multi_chain(
+    Antlr4Gen::SecLangParser::Action_extension_multi_chainContext* ctx) {
+  chain_ = true;
+
+  Action::ActionBase::Branch branch = Action::ActionBase::Branch::Matched;
+  if (ctx->ALWAYS() || ctx->UNMATCHED()) {
+    if (current_rule_->visitActionMode() != CurrentRule::VisitActionMode::SecRule) {
+      RETURN_ERROR("The ALWAYS and UNMATCHED branches are only allowed in SecRule actions.");
+    }
+    branch =
+        ctx->ALWAYS() ? Action::ActionBase::Branch::Always : Action::ActionBase::Branch::Unmatched;
+  }
+
+  switch (branch) {
+  case Action::ActionBase::Branch::Matched:
+    current_rule_->get()->matchedMultiChain(true);
+    break;
+  case Action::ActionBase::Branch::Unmatched:
+    current_rule_->get()->unmatchedMultiChain(true);
+    break;
+  case Action::ActionBase::Branch::Always:
+    current_rule_->get()->matchedMultiChain(true);
+    current_rule_->get()->unmatchedMultiChain(true);
+    break;
+  default:
+    break;
+  }
+
+  return EMPTY_STRING;
+}
+
 std::any Visitor::visitSec_audit_engine(Antlr4Gen::SecLangParser::Sec_audit_engineContext* ctx) {
   using Option = Wge::AuditLogConfig::AuditEngine;
   Option option = Option::Off;

--- a/src/antlr4/visitor.h
+++ b/src/antlr4/visitor.h
@@ -825,9 +825,10 @@ public:
 public:
   std::any visitAction_extension_first_match(
       Antlr4Gen::SecLangParser::Action_extension_first_matchContext* ctx) override;
-
   std::any visitAction_extension_empty_match(
       Antlr4Gen::SecLangParser::Action_extension_empty_matchContext* ctx) override;
+  std::any visitAction_extension_multi_chain(
+      Antlr4Gen::SecLangParser::Action_extension_multi_chainContext* ctx) override;
 
   // Audit log configurations
 public:

--- a/src/rule.h
+++ b/src/rule.h
@@ -161,6 +161,18 @@ public:
   void unmatchedChain(bool value) {
     flags_.set(static_cast<size_t>(Flags::UNMATCHED_CHAIN), value);
   }
+  bool matchedMultiChain() const {
+    return flags_.test(static_cast<size_t>(Flags::MATCHED_MULTI_CHAIN));
+  }
+  void matchedMultiChain(bool value) {
+    flags_.set(static_cast<size_t>(Flags::MATCHED_MULTI_CHAIN), value);
+  }
+  bool unmatchedMultiChain() const {
+    return flags_.test(static_cast<size_t>(Flags::UNMATCHED_MULTI_CHAIN));
+  }
+  void unmatchedMultiChain(bool value) {
+    flags_.set(static_cast<size_t>(Flags::UNMATCHED_MULTI_CHAIN), value);
+  }
   const std::vector<std::unique_ptr<Transformation::TransformBase>>& transforms() const {
     return transforms_;
   }
@@ -327,6 +339,14 @@ private:
 
     // Indicates that the unmatched branch actions have chain action.
     UNMATCHED_CHAIN,
+
+    // If enabled, WGE will continue evaluating the chained rules when every variable value of the
+    // rule is matched. (By default, WGE will evaluating the chained rules after all variable values
+    // were evaluated and the rule matched).
+    MATCHED_MULTI_CHAIN,
+
+    // Similar to MATCHED_MULTI_CHAIN, but for the unmatched branch.
+    UNMATCHED_MULTI_CHAIN,
 
     // If enabled, WGE will ignore the default transformation for the matched variable.
     IGNORE_DEFAULT_TRANSFORM,


### PR DESCRIPTION
The multiChain action allows a rule to match chained rules after evaluated a variable value every time. It also supports the unmatched branch.