### PR TITLE
feat(antlr4): support alias action

### DIFF
--- a/src/antlr4/SecLangParser.g4
+++ b/src/antlr4/SecLangParser.g4
@@ -947,7 +947,8 @@ extension_variable:
 	variable_ptree
 	| variable_gtx
 	| variable_matched_vptree
-	| variable_matched_optree;
+	| variable_matched_optree
+	| variable_alias;
 variable_ptree:
 	NOT? VAR_COUNT? VAR_PTREE (COLON | DOT) variable_ptree_expression;
 variable_ptree_expression:
@@ -976,6 +977,10 @@ variable_matched_optree:
 	NOT? VAR_COUNT? VAR_MATCHED_OPTREE (
 		((COLON | DOT) variable_ptree_expression)
 		| (PARENT+ variable_ptree_expression?)
+	)?;
+variable_alias:
+	NOT? VAR_COUNT? VAR_ALIAS (
+		(COLON | DOT) variable_ptree_expression
 	)?;
 
 operator:
@@ -1416,10 +1421,26 @@ action_flow_skip_after: SkipAfter COLON STRING;
 action_extension:
 	action_extension_first_match
 	| action_extension_empty_match
-	| action_extension_multi_chain;
+	| action_extension_multi_chain
+	| action_extension_alias;
 action_extension_first_match: FirstMatch;
 action_extension_empty_match: EmptyMatch;
 action_extension_multi_chain: (ALWAYS | UNMATCHED)? MultiChain;
+action_extension_alias:
+	Alias COLON (
+		(
+			SINGLE_QUOTE ALIAS_NAME ASSIGN (
+				variable_matched_optree
+				| variable_matched_vptree
+			) SINGLE_QUOTE
+		)
+		| (
+			ALIAS_NAME ASSIGN (
+				variable_matched_optree
+				| variable_matched_vptree
+			)
+		)
+	);
 
 audit_log_config:
 	sec_audit_engine

--- a/src/antlr4/debug/debug_lexer.cc
+++ b/src/antlr4/debug/debug_lexer.cc
@@ -4,6 +4,39 @@
 #include "antlr4-runtime.h"
 #include "antlr4_gen/SecLangLexer.h"
 
+class DebugLexer : public Wge::Antlr4::Antlr4Gen::SecLangLexer {
+public:
+  explicit DebugLexer(antlr4::CharStream* input) : SecLangLexer(input) {}
+
+  std::unique_ptr<antlr4::Token> nextToken() override {
+    // Get current mode name
+    std::string current_mode_name = "DEFAULT";
+    if (mode < getModeNames().size()) {
+      current_mode_name = getModeNames()[mode];
+    }
+
+    auto token = SecLangLexer::nextToken();
+
+    // Get token type name from vocabulary
+    std::string token_name = "UNKNOWN";
+    if (token->getType() != antlr4::Token::EOF &&
+        token->getType() < getVocabulary().getMaxTokenType()) {
+      auto symbolicName = getVocabulary().getSymbolicName(token->getType());
+      if (!symbolicName.empty()) {
+        token_name = symbolicName;
+      }
+    } else if (token->getType() == antlr4::Token::EOF) {
+      token_name = "EOF";
+    }
+
+    // Print token information with mode and token name
+    std::cout << token->toString() << " [mode: " << current_mode_name << ", token: " << token_name
+              << "]" << std::endl;
+
+    return token;
+  }
+};
+
 int main(int argc, char* argv[]) {
   using namespace antlr4;
   using namespace Wge::Antlr4::Antlr4Gen;
@@ -21,14 +54,12 @@ int main(int argc, char* argv[]) {
   }
 
   ANTLRInputStream input(stream);
-  SecLangLexer lexer(&input);
-  CommonTokenStream tokens(&lexer);
+  DebugLexer lexer(&input);
 
-  tokens.fill();
-
-  for (auto token : tokens.getTokens()) {
-    std::cout << token->toString() << std::endl;
-  }
+  std::unique_ptr<Token> token;
+  do {
+    token = lexer.nextToken();
+  } while (token->getType() != Token::EOF);
 
   return 0;
 }


### PR DESCRIPTION
The alias action is a compile-time directive that allows users to create shortcuts or alternative names for MATCHED_OPTREE and MATCHED_VPTREE that have complex paths. This enhancement simplifies rule definitions and improves readability by enabling the use of aliases instead of lengthy variable paths.