### PR TITLE
fix: MATCHED_VPTREE and MATCHED_OPTREE variables

### DIFF
--- a/src/operator/begins_with.h
+++ b/src/operator/begins_with.h
@@ -70,7 +70,8 @@ public:
               }
 
             results.emplace_back(std::get<std::string_view>(operand).starts_with(
-                std::get<std::string_view>(right_operand.variant_)));
+                                     std::get<std::string_view>(right_operand.variant_)),
+                                 "", right_operand.ptree_node_);
             WGE_LOG_TRACE([&]() {
               std::string sub_name;
               if (!right_operand.variable_sub_name_.empty()) {

--- a/src/operator/contains.h
+++ b/src/operator/contains.h
@@ -72,7 +72,8 @@ public:
 
             results.emplace_back(std::get<std::string_view>(operand).find(
                                      std::get<std::string_view>(right_operand.variant_)) !=
-                                 std::string_view::npos);
+                                     std::string_view::npos,
+                                 "", right_operand.ptree_node_);
             WGE_LOG_TRACE([&]() {
               std::string sub_name;
               if (!right_operand.variable_sub_name_.empty()) {

--- a/src/operator/ends_with.h
+++ b/src/operator/ends_with.h
@@ -65,7 +65,8 @@ public:
               }
 
             results.emplace_back(std::get<std::string_view>(operand).ends_with(
-                std::get<std::string_view>(right_operand.variant_)));
+                                     std::get<std::string_view>(right_operand.variant_)),
+                                 "", right_operand.ptree_node_);
             WGE_LOG_TRACE([&]() {
               std::string sub_name;
               if (!right_operand.variable_sub_name_.empty()) {

--- a/src/operator/eq.h
+++ b/src/operator/eq.h
@@ -72,7 +72,8 @@ public:
               }
 
             results.emplace_back(std::get<int64_t>(operand) ==
-                                 std::get<int64_t>(right_operand.variant_));
+                                     std::get<int64_t>(right_operand.variant_),
+                                 "", right_operand.ptree_node_);
             WGE_LOG_TRACE([&]() {
               std::string sub_name;
               if (!right_operand.variable_sub_name_.empty()) {

--- a/src/operator/ge.h
+++ b/src/operator/ge.h
@@ -67,7 +67,8 @@ public:
               }
 
             results.emplace_back(std::get<int64_t>(operand) >=
-                                 std::get<int64_t>(right_operand.variant_));
+                                     std::get<int64_t>(right_operand.variant_),
+                                 "", right_operand.ptree_node_);
             WGE_LOG_TRACE([&]() {
               std::string sub_name;
               if (!right_operand.variable_sub_name_.empty()) {

--- a/src/operator/gt.h
+++ b/src/operator/gt.h
@@ -67,7 +67,8 @@ public:
               }
 
             results.emplace_back(std::get<int64_t>(operand) >
-                                 std::get<int64_t>(right_operand.variant_));
+                                     std::get<int64_t>(right_operand.variant_),
+                                 "", right_operand.ptree_node_);
             WGE_LOG_TRACE([&]() {
               std::string sub_name;
               if (!right_operand.variable_sub_name_.empty()) {

--- a/src/operator/le.h
+++ b/src/operator/le.h
@@ -67,7 +67,8 @@ public:
               }
 
             results.emplace_back(std::get<int64_t>(operand) <=
-                                 std::get<int64_t>(right_operand.variant_));
+                                     std::get<int64_t>(right_operand.variant_),
+                                 "", right_operand.ptree_node_);
             WGE_LOG_TRACE([&]() {
               std::string sub_name;
               if (!right_operand.variable_sub_name_.empty()) {

--- a/src/operator/lt.h
+++ b/src/operator/lt.h
@@ -67,7 +67,8 @@ public:
               }
 
             results.emplace_back(std::get<int64_t>(operand) <
-                                 std::get<int64_t>(right_operand.variant_));
+                                     std::get<int64_t>(right_operand.variant_),
+                                 "", right_operand.ptree_node_);
             WGE_LOG_TRACE([&]() {
               std::string sub_name;
               if (!right_operand.variable_sub_name_.empty()) {

--- a/src/operator/operator_base.h
+++ b/src/operator/operator_base.h
@@ -24,6 +24,7 @@
 
 #include <absl/container/inlined_vector.h>
 
+#include "../common/property_tree.h"
 #include "../common/variant.h"
 #include "../macro/macro_base.h"
 #include "../transaction.h"
@@ -43,8 +44,9 @@ namespace Operator {
 class OperatorBase {
 public:
   struct Result {
-    bool matched_;
+    bool matched_{false};
     std::string_view capture_;
+    const Common::PropertyTree* ptree_node_{nullptr};
   };
   using Results = absl::InlinedVector<Result, 1>;
 

--- a/src/operator/rx.h
+++ b/src/operator/rx.h
@@ -111,7 +111,8 @@ public:
 
               if (!result.empty()) {
                 for (const auto& [from, to] : result) {
-                  results.emplace_back(true, std::string_view{left_str.data() + from, to - from});
+                  results.emplace_back(true, std::string_view{left_str.data() + from, to - from},
+                                       right_operand.ptree_node_);
                 }
               } else {
                 results.emplace_back(false);

--- a/src/operator/streq.h
+++ b/src/operator/streq.h
@@ -69,7 +69,8 @@ public:
               }
 
             results.emplace_back(std::get<std::string_view>(operand) ==
-                                 std::get<std::string_view>(right_operand.variant_));
+                                     std::get<std::string_view>(right_operand.variant_),
+                                 "", right_operand.ptree_node_);
 
             WGE_LOG_TRACE([&]() {
               std::string sub_name;

--- a/src/operator/within.h
+++ b/src/operator/within.h
@@ -126,8 +126,10 @@ public:
 
               bool matched = result.first != result.second;
               if (matched) {
-                results.emplace_back(true, std::string_view{left_operand_str.data() + result.first,
-                                                            result.second - result.first});
+                results.emplace_back(true,
+                                     std::string_view{left_operand_str.data() + result.first,
+                                                      result.second - result.first},
+                                     right_operand.ptree_node_);
               } else {
                 results.emplace_back(false);
               }

--- a/src/operator/xor.h
+++ b/src/operator/xor.h
@@ -70,7 +70,8 @@ public:
               }
 
             results.emplace_back(
-                (std::get<int64_t>(operand) ^ std::get<int64_t>(right_operand.variant_)) != 0);
+                (std::get<int64_t>(operand) ^ std::get<int64_t>(right_operand.variant_)) != 0, "",
+                right_operand.ptree_node_);
             WGE_LOG_TRACE([&]() {
               std::string sub_name;
               if (!right_operand.variable_sub_name_.empty()) {

--- a/src/rule.cc
+++ b/src/rule.cc
@@ -210,6 +210,10 @@ bool Rule::evaluate(Transaction& t) const {
             t.pushMatchedVPTree(chain_index_, variable_value.ptree_node_);
           }
 
+          if (op_result.ptree_node_) {
+            t.pushMatchedOPTree(chain_index_, op_result.ptree_node_);
+          }
+
           rule_matched = true;
 
           // Evaluate the matched branch actions
@@ -506,9 +510,9 @@ void Rule::evaluateActions(Transaction& t, Action::ActionBase::Branch branch) co
   }
 }
 
-// Normally, variables are inspected only once per rule, and only after all transformation functions
-// have been completed. With multiMatch, variables are checked against the operator before and after
-// every transformation function that changes the input.
+// Normally, variables are inspected only once per rule, and only after all transformation
+// functions have been completed. With multiMatch, variables are checked against the operator
+// before and after every transformation function that changes the input.
 bool Rule::evaluateWithMultiMatch(Transaction& t) const {
   // Get all of the transformations
   std::vector<Transformation::TransformBase*> transforms;
@@ -573,6 +577,10 @@ bool Rule::evaluateWithMultiMatch(Transaction& t) const {
 
           if (evaluated_value->ptree_node_) {
             t.pushMatchedVPTree(chain_index_, evaluated_value->ptree_node_);
+          }
+
+          if (op_result.ptree_node_) {
+            t.pushMatchedOPTree(chain_index_, op_result.ptree_node_);
           }
 
           variable_matched = true;

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -467,37 +467,16 @@ public:
   }
 
   /**
-   * Stage a matched operator property tree node. After staging, we should call
-   * commitMatchedOPTree() to commit the staged matched operator property tree nodes into the main
-   * matched operator, then we can use getMatchedOPTrees() to get the matched operator property tree
-   * nodes.
+   * Add a matched operator property tree node.
+   * Use for MATCHED_OPTREE.
+   * @param rule_chain_index the chain index of the rule that matched this node
    * @param optree the matched operator property tree node.
    */
-  void stageMatchedOPTree(const Common::PropertyTree* optree) {
-    temp_matched_optrees_.emplace_back(optree);
-  }
-
-  /**
-   * Rollback the staged matched operator property tree nodes.
-   */
-  void rollbackMatchedOPTree() { temp_matched_optrees_.clear(); }
-
-  /**
-   * Commit the staged matched operator property tree nodes into the main matched operator property
-   * tree nodes.
-   * After calling this method, we can use getMatchedOPTrees() to get the matched operator property
-   * tree nodes.
-   * @param rule_chain_index the chain index of the rule that matched these nodes
-   * @return the number of matched operator property tree nodes that are committed.
-   */
-  size_t commitMatchedOPTree(RuleChainIndexType rule_chain_index) {
+  void pushMatchedOPTree(RuleChainIndexType rule_chain_index, const Common::PropertyTree* optree) {
     auto& optrees =
         matched_optrees_.try_emplace(rule_chain_index, std::vector<const Common::PropertyTree*>())
             .first->second;
-    optrees.insert(optrees.end(), temp_matched_optrees_.begin(), temp_matched_optrees_.end());
-    size_t count = temp_matched_optrees_.size();
-    temp_matched_optrees_.clear();
-    return count;
+    optrees.emplace_back(optree);
   }
 
   /**
@@ -667,7 +646,6 @@ private:
   // - Value: vector of all PTree nodes that matched within that specific rule
   // Used by MATCHED_OPTREE and MATCHED_VPTREE variables.
   std::unordered_map<RuleChainIndexType, std::vector<const Common::PropertyTree*>> matched_optrees_;
-  std::vector<const Common::PropertyTree*> temp_matched_optrees_;
   std::unordered_map<RuleChainIndexType, std::vector<const Common::PropertyTree*>> matched_vptrees_;
 
   // All of the transaction instances share the same rule instances, and each transaction instance

--- a/src/variable/matched_optree.h
+++ b/src/variable/matched_optree.h
@@ -70,7 +70,11 @@ public:
       }
     }
 
-    Variable::PTree::evaluateNode(matched_optree, paths_, 0, result);
+    if (paths_.empty()) {
+      Variable::PTree::evaluateNode(matched_optree, result);
+    } else {
+      Variable::PTree::evaluateNode(matched_optree, paths_, 0, result);
+    }
   }
 };
 } // namespace Variable

--- a/src/variable/matched_vptree.h
+++ b/src/variable/matched_vptree.h
@@ -70,7 +70,11 @@ public:
       }
     }
 
-    Variable::PTree::evaluateNode(matched_vptree, paths_, 0, result);
+    if (paths_.empty()) {
+      Variable::PTree::evaluateNode(matched_vptree, result);
+    } else {
+      Variable::PTree::evaluateNode(matched_vptree, paths_, 0, result);
+    }
   }
 };
 } // namespace Variable

--- a/src/variable/ptree.cc
+++ b/src/variable/ptree.cc
@@ -27,7 +27,11 @@
 namespace Wge {
 namespace Variable {
 void Variable::PTree::evaluate(Transaction& t, Common::EvaluateResults& result) const {
-  evaluateNode(&t.getEngine().propertyTree(), paths_, 0, result);
+  if (paths_.empty()) {
+    evaluateNode(&t.getEngine().propertyTree(), result);
+  } else {
+    evaluateNode(&t.getEngine().propertyTree(), paths_, 0, result);
+  }
 }
 
 void PTree::initPaths(const std::string& sub_name, std::vector<Path>& paths) {
@@ -81,7 +85,8 @@ void PTree::evaluateNode(const Common::PropertyTree* node, const std::vector<Pat
       // If it's the last node and it's a map, we return the values of the map
       if (i == paths.size() - 1) {
         for (const auto& [key, child_tree] : *current_node) {
-          result.emplace_back(child_tree.data(), key);
+          result.emplace_back(child_tree.data(), key,
+                              static_cast<const Common::PropertyTree*>(&child_tree));
         }
       }
     } break;
@@ -97,7 +102,8 @@ void PTree::evaluateNode(const Common::PropertyTree* node, const std::vector<Pat
       if (i == paths.size() - 1) {
         // If it's the last node and it's an array, we return the values of the array
         for (const auto& [key, child_tree] : *current_node) {
-          result.emplace_back(child_tree.data(), key);
+          result.emplace_back(child_tree.data(), key,
+                              static_cast<const Common::PropertyTree*>(&child_tree));
         }
       } else {
         // Otherwise, we walk through each element in the array
@@ -108,16 +114,32 @@ void PTree::evaluateNode(const Common::PropertyTree* node, const std::vector<Pat
       }
     } break;
     case Path::Type::Value: {
-      auto value = current_node->get_optional<Common::PropertyTreeValue>(path.name_);
-      if (!value) {
+      auto child = current_node->get_child_optional(path.name_);
+      if (!child) {
         WGE_LOG_WARN("The value node '{}' is not found in the property tree.", path.name_);
         result.clear();
         return;
       }
-      result.emplace_back(value.get(), path.name_);
+      result.emplace_back(child->data(), path.name_,
+                          static_cast<const Common::PropertyTree*>(&child.get()));
     } break;
     default:
       break;
+    }
+  }
+}
+
+void PTree::evaluateNode(const Common::PropertyTree* node, Common::EvaluateResults& result) {
+  if (node->empty()) {
+    result.emplace_back(node->data(), "", static_cast<const Common::PropertyTree*>(node));
+  } else {
+    for (const auto& [_, child_tree] : *node) {
+      if (child_tree.empty()) {
+        result.emplace_back(child_tree.data(), "",
+                            static_cast<const Common::PropertyTree*>(&child_tree));
+      } else {
+        evaluateNode(static_cast<const Common::PropertyTree*>(&child_tree), result);
+      }
     }
   }
 }

--- a/src/variable/ptree.h
+++ b/src/variable/ptree.h
@@ -53,6 +53,7 @@ public:
 
   static void evaluateNode(const Common::PropertyTree* node, const std::vector<Path>& paths,
                            size_t path_index, Common::EvaluateResults& result);
+  static void evaluateNode(const Common::PropertyTree* node, Common::EvaluateResults& result);
 
 private:
   std::vector<Path> paths_;

--- a/test/integration/01_variable.cc
+++ b/test/integration/01_variable.cc
@@ -944,8 +944,7 @@ TEST_F(VariableTest, MATCHED_OPTREE) {
     auto& matched_optree =
         engine.propertyTree().get_child("config.server_list").front().second.get_child("port");
     EXPECT_EQ(std::get<int64_t>(matched_optree.data()), 8080);
-    t->stageMatchedOPTree(static_cast<const Common::PropertyTree*>(&matched_optree));
-    t->commitMatchedOPTree(-1);
+    t->pushMatchedOPTree(-1, static_cast<const Common::PropertyTree*>(&matched_optree));
     Variable::MatchedOPTree var("../host", false, false, "");
     result.clear();
     var.evaluate(*t, result);
@@ -962,8 +961,7 @@ TEST_F(VariableTest, MATCHED_OPTREE) {
                                .front()
                                .second;
     EXPECT_EQ(std::get<std::string_view>(matched_optree.data()), "staging");
-    t->stageMatchedOPTree(static_cast<const Common::PropertyTree*>(&matched_optree));
-    t->commitMatchedOPTree(-1);
+    t->pushMatchedOPTree(-1, static_cast<const Common::PropertyTree*>(&matched_optree));
     Variable::MatchedOPTree var("../../domain.name", false, false, "");
     result.clear();
     var.evaluate(*t, result);


### PR DESCRIPTION
- Fix not setting MATCHED_VPTREE and MATCHED_OPTREE variables when evaluating rule
- Fix the results of MATCHED_VPTREE and MATCHED_OPTREE variables when no specific paths are provided.