### PR TITLE
fix(engine): fix property tree parsing

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -77,6 +77,11 @@ public:
    * content are correct.
    * @param json_string JSON string representing engine properties
    * @result an error string is returned if fails, and returned true otherwise
+   * @note The json values are stored in Common::Variant as follows:
+   * - string: string_view
+   * - number: int64_t (multiplied by 100 if it is a floating point number)
+   * - boolean: int64_t (1 for true, 0 for false)
+   * - null: std::monostate
    */
   std::expected<bool, std::string> propertyTree(const std::string& json_string);
 

--- a/test/integration/01_variable.cc
+++ b/test/integration/01_variable.cc
@@ -834,7 +834,13 @@ TEST_F(VariableTest, PTREE) {
                     "v1.1"
                 ]
             }
-        ]
+        ],
+        "boolean_test1": true,
+        "boolean_test2": false,
+        "null_test": null,
+        "float_test": 3.14159,
+        "minus_test": -100,
+        "minus_float_test": -3.14159
     }
 })";
 
@@ -895,6 +901,54 @@ TEST_F(VariableTest, PTREE) {
     EXPECT_EQ(std::get<std::string_view>(result[1].variant_), "v1.0");
     EXPECT_EQ(std::get<std::string_view>(result[2].variant_), "staging");
     EXPECT_EQ(std::get<std::string_view>(result[3].variant_), "v1.1");
+  }
+
+  {
+    Variable::PTree var("config.boolean_test1", false, false, "");
+    result.clear();
+    var.evaluate(*t, result);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(std::get<std::int64_t>(result[0].variant_), 1);
+  }
+
+  {
+    Variable::PTree var("config.boolean_test2", false, false, "");
+    result.clear();
+    var.evaluate(*t, result);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(std::get<std::int64_t>(result[0].variant_), 0);
+  }
+
+  {
+    Variable::PTree var("config.null_test", false, false, "");
+    result.clear();
+    var.evaluate(*t, result);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_TRUE(IS_EMPTY_VARIANT(result[0].variant_));
+  }
+
+  {
+    Variable::PTree var("config.float_test", false, false, "");
+    result.clear();
+    var.evaluate(*t, result);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(std::get<int64_t>(result[0].variant_), 314);
+  }
+
+  {
+    Variable::PTree var("config.minus_test", false, false, "");
+    result.clear();
+    var.evaluate(*t, result);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(std::get<int64_t>(result[0].variant_), -100);
+  }
+
+  {
+    Variable::PTree var("config.minus_float_test", false, false, "");
+    result.clear();
+    var.evaluate(*t, result);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(std::get<int64_t>(result[0].variant_), -314);
   }
 }
 


### PR DESCRIPTION
Handle parsing of boolean, null, and float in property trees correctly