### PR TITLE
feat(engine): support dynamic update property tree

### DIFF
--- a/src/antlr4/visitor.h
+++ b/src/antlr4/visitor.h
@@ -834,7 +834,8 @@ public:
       Antlr4Gen::SecLangParser::Action_extension_multi_chainContext* ctx) override;
   std::any visitAction_extension_alias(
       Antlr4Gen::SecLangParser::Action_extension_aliasContext* ctx) override;
-  std::any visitAction_extension_reply(Antlr4Gen::SecLangParser::Action_extension_replyContext* ctx) override;
+  std::any visitAction_extension_reply(
+      Antlr4Gen::SecLangParser::Action_extension_replyContext* ctx) override;
 
   // Audit log configurations
 public:

--- a/src/common/property_store.cc
+++ b/src/common/property_store.cc
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ *
+ * MIT License (http://opensource.org/licenses/MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "property_store.h"
+
+#include <sstream>
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include "log.h"
+
+namespace Wge {
+namespace Common {
+std::expected<bool, std::string> PropertyStore::loadFromJsonString(const std::string& json_string) {
+  std::istringstream iss(json_string);
+  boost::property_tree::ptree temp_ptree;
+  try {
+    boost::property_tree::read_json(iss, temp_ptree);
+  } catch (const boost::property_tree::json_parser_error& e) {
+    WGE_LOG_ERROR("Failed to parse property tree JSON string: {}", e.what());
+    return std::unexpected<std::string>(e.what());
+  }
+
+  string_pool_.reserve(json_string.size());
+  convertPtreeToPropertyTree(temp_ptree, property_tree_);
+
+  return true;
+}
+
+void PropertyStore::convertPtreeToPropertyTree(const boost::property_tree::ptree& src,
+                                               Common::PropertyTree& dest) {
+  // The array detection: all keys are empty strings
+  bool is_array = std::all_of(src.begin(), src.end(), [](const auto& pair) {
+    if (pair.first.empty()) {
+      return true;
+    }
+    return false;
+  });
+
+  if (is_array) {
+    for (const auto& [_, child_tree] : src) {
+      if (child_tree.empty()) {
+        // Leaf node - convert the value
+        dest.push_back(std::make_pair("", Common::PropertyTree(&dest)));
+        Common::PropertyTree* new_tree = static_cast<Common::PropertyTree*>(&dest.back().second);
+        new_tree->put("", convertValue(child_tree.data(), &dest));
+      } else {
+        // Branch node - recursively convert children
+        dest.push_back(std::make_pair("", Common::PropertyTree(&dest)));
+        Common::PropertyTree* new_tree = static_cast<Common::PropertyTree*>(&dest.back().second);
+        convertPtreeToPropertyTree(child_tree, *new_tree);
+      }
+    }
+  } else {
+    for (const auto& [key, child_tree] : src) {
+      if (child_tree.empty()) {
+        // Leaf node - convert the value
+        dest.put(key, convertValue(child_tree.data(), &dest));
+      } else {
+        // Branch node - recursively convert children
+        Common::PropertyTree* new_tree =
+            static_cast<Common::PropertyTree*>(&dest.put_child(key, Common::PropertyTree(&dest)));
+        convertPtreeToPropertyTree(child_tree, *new_tree);
+      }
+    }
+  }
+}
+
+Common::PropertyTreeValue PropertyStore::convertValue(const std::string& value,
+                                                      Common::PropertyTree* parent) {
+  if (value.empty()) {
+    return {std::monostate{}, parent};
+  }
+
+  // Try to parse as boolean or null
+  if (value == "true") {
+    return {1, parent};
+  } else if (value == "false") {
+    return {0, parent};
+  } else if (value == "null") {
+    return {std::monostate{}, parent};
+  }
+
+  // Try to parse as number (integer or floating point)
+  bool has_dot = false;
+  bool is_valid_number = true;
+  for (size_t i = 0; i < value.size() && is_valid_number; ++i) {
+    const char& c = value[i];
+    if (c == '.') {
+      if (has_dot || i == 0 || i == value.size() - 1) {
+        is_valid_number = false;
+      } else {
+        has_dot = true;
+      }
+    } else if (c == '-') {
+      if (i != 0) {
+        is_valid_number = false;
+      }
+    } else if (!std::isdigit(c)) {
+      is_valid_number = false;
+    }
+  }
+  if (is_valid_number) {
+    if (has_dot) {
+      // Parse as floating point and convert to integer (multiply by 100)
+      double double_value = 0;
+      std::from_chars(value.data(), value.data() + value.size(), double_value);
+      return {static_cast<int64_t>(std::round(double_value * 100)), parent};
+    } else {
+      // Parse as integer
+      int64_t int_value = 0;
+      std::from_chars(value.data(), value.data() + value.size(), int_value);
+      return {int_value, parent};
+    }
+  }
+
+  string_pool_.append(value);
+  return {std::string_view(string_pool_.data() + string_pool_.size() - value.size(), value.size()),
+          parent};
+}
+
+} // namespace Common
+} // namespace Wge

--- a/src/common/property_store.h
+++ b/src/common/property_store.h
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ *
+ * MIT License (http://opensource.org/licenses/MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <expected>
+#include <string>
+
+#include "property_tree.h"
+
+namespace Wge {
+namespace Common {
+/**
+ * PropertyStore class manages a PropertyTree and its associated string memory pool.
+ */
+class PropertyStore {
+public:
+  PropertyStore() = default;
+  PropertyStore(const PropertyStore&) = delete;
+  PropertyStore& operator=(const PropertyStore&) = delete;
+  PropertyStore(PropertyStore&&) = default;
+  PropertyStore& operator=(PropertyStore&&) = default;
+
+public:
+  /**
+   * Constructs a PropertyStore from a JSON string.
+   * @param json_string JSON string representing the property tree
+   * @return an expected object containing true if successful, or an error string if failed
+   * @note The json values are stored in Common::Variant as follows:
+   * - string: string_view
+   * - number: int64_t (multiplied by 100 if it is a floating point number)
+   * - boolean: int64_t (1 for true, 0 for false)
+   * - null: std::monostate
+   */
+  std::expected<bool, std::string> loadFromJsonString(const std::string& json_string);
+
+  /**
+   * Clears the property tree and the string pool.
+   */
+  void clear() {
+    property_tree_.clear();
+    string_pool_.clear();
+  }
+
+  /**
+   * Gets the property tree.
+   * @return reference to the PropertyTree
+   */
+  PropertyTree& getPropertyTree() { return property_tree_; }
+
+  /**
+   * Gets the property tree (const version).
+   * @return const reference to the PropertyTree
+   */
+  const PropertyTree& getPropertyTree() const { return property_tree_; }
+
+private:
+  void convertPtreeToPropertyTree(const boost::property_tree::ptree& src,
+                                  Common::PropertyTree& dest);
+  Common::PropertyTreeValue convertValue(const std::string& value, Common::PropertyTree* parent);
+
+private:
+  PropertyTree property_tree_;
+  std::string string_pool_;
+};
+
+} // namespace Common
+} // namespace Wge

--- a/src/common/property_tree.h
+++ b/src/common/property_tree.h
@@ -32,6 +32,12 @@ struct PropertyTreeValue : public Common::Variant {
   PropertyTree* parent_{nullptr};
 };
 
+/**
+ * PropertyTree is a subclass of boost::property_tree::basic_ptree with PropertyTreeValue as the
+ * data type. It adds a parent pointer to each node for accessing parent node information when
+ * needed. Its value type is PropertyTreeValue, which inherits from Common::Variant and can store
+ * multiple data types.
+ */
 class PropertyTree : public boost::property_tree::basic_ptree<std::string, PropertyTreeValue> {
 public:
   PropertyTree(PropertyTree* parent = nullptr)

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -20,8 +20,6 @@
  */
 #include "engine.h"
 
-#include <boost/property_tree/json_parser.hpp>
-
 #include "action/ctl.h"
 #include "antlr4/parser.h"
 #include "common/assert.h"
@@ -60,24 +58,15 @@ std::expected<bool, std::string> Engine::load(const std::string& directive) {
   return parser_->load(directive);
 }
 
-std::expected<bool, std::string> Engine::propertyTree(const std::string& json_string) {
-  ASSERT_IS_MAIN_THREAD();
-
-  std::istringstream iss(json_string);
-  boost::property_tree::ptree temp_ptree;
-  try {
-    boost::property_tree::read_json(iss, temp_ptree);
-  } catch (const boost::property_tree::json_parser_error& e) {
-    WGE_LOG_ERROR("Failed to parse property tree JSON string: {}", e.what());
-    return std::unexpected<std::string>(e.what());
+std::expected<bool, std::string> Engine::updatePropertyStore(const std::string& json_string) {
+  std::shared_ptr<Common::PropertyStore> new_property_store =
+      std::make_shared<Common::PropertyStore>();
+  auto result = new_property_store->loadFromJsonString(json_string);
+  if (!result.has_value()) {
+    return std::unexpected<std::string>(result.error());
   }
 
-  // Convert ptree to PropertyTree
-  property_tree_.clear();
-  property_tree_string_pool_.clear();
-  property_tree_string_pool_.reserve(json_string.size());
-  convertPtreeToPropertyTree(temp_ptree, property_tree_);
-
+  property_store_ = std::move(new_property_store);
   return true;
 }
 
@@ -104,7 +93,10 @@ const std::vector<Rule>& Engine::rules(RulePhaseType phase) const {
 
 TransactionPtr Engine::makeTransaction() const {
   assert(is_init_);
-  return std::unique_ptr<Transaction>(new Transaction(*this));
+
+  // Create a new transaction
+  // Each transaction has its own property store snapshot
+  return std::unique_ptr<Transaction>(new Transaction(*this, property_store_.load()));
 }
 
 const EngineConfig& Engine::config() const { return parser_->engineConfig(); }
@@ -209,99 +201,4 @@ void Engine::initRules() {
     }
   }
 }
-
-void Engine::convertPtreeToPropertyTree(const boost::property_tree::ptree& src,
-                                        Common::PropertyTree& dest) {
-  auto convertValue = [&](const std::string& value,
-                          Common::PropertyTree* parent) -> Common::PropertyTreeValue {
-    if (value.empty()) {
-      return {std::monostate{}, parent};
-    }
-
-    // Try to parse as boolean or null
-    if (value == "true") {
-      return {1, parent};
-    } else if (value == "false") {
-      return {0, parent};
-    } else if (value == "null") {
-      return {std::monostate{}, parent};
-    }
-
-    // Try to parse as number (integer or floating point)
-    bool has_dot = false;
-    bool is_valid_number = true;
-    for (size_t i = 0; i < value.size() && is_valid_number; ++i) {
-      const char& c = value[i];
-      if (c == '.') {
-        if (has_dot || i == 0 || i == value.size() - 1) {
-          is_valid_number = false;
-        } else {
-          has_dot = true;
-        }
-      } else if (c == '-') {
-        if (i != 0) {
-          is_valid_number = false;
-        }
-      } else if (!std::isdigit(c)) {
-        is_valid_number = false;
-      }
-    }
-    if (is_valid_number) {
-      if (has_dot) {
-        // Parse as floating point and convert to integer (multiply by 100)
-        double double_value = 0;
-        std::from_chars(value.data(), value.data() + value.size(), double_value);
-        return {static_cast<int64_t>(std::round(double_value * 100)), parent};
-      } else {
-        // Parse as integer
-        int64_t int_value = 0;
-        std::from_chars(value.data(), value.data() + value.size(), int_value);
-        return {int_value, parent};
-      }
-    }
-
-    property_tree_string_pool_.append(value);
-    return {std::string_view(property_tree_string_pool_.data() + property_tree_string_pool_.size() -
-                                 value.size(),
-                             value.size()),
-            parent};
-  };
-
-  // The array detection: all keys are empty strings
-  bool is_array = std::all_of(src.begin(), src.end(), [](const auto& pair) {
-    if (pair.first.empty()) {
-      return true;
-    }
-    return false;
-  });
-
-  if (is_array) {
-    for (const auto& [_, child_tree] : src) {
-      if (child_tree.empty()) {
-        // Leaf node - convert the value
-        dest.push_back(std::make_pair("", Common::PropertyTree(&dest)));
-        Common::PropertyTree* new_tree = static_cast<Common::PropertyTree*>(&dest.back().second);
-        new_tree->put("", convertValue(child_tree.data(), &dest));
-      } else {
-        // Branch node - recursively convert children
-        dest.push_back(std::make_pair("", Common::PropertyTree(&dest)));
-        Common::PropertyTree* new_tree = static_cast<Common::PropertyTree*>(&dest.back().second);
-        convertPtreeToPropertyTree(child_tree, *new_tree);
-      }
-    }
-  } else {
-    for (const auto& [key, child_tree] : src) {
-      if (child_tree.empty()) {
-        // Leaf node - convert the value
-        dest.put(key, convertValue(child_tree.data(), &dest));
-      } else {
-        // Branch node - recursively convert children
-        Common::PropertyTree* new_tree =
-            static_cast<Common::PropertyTree*>(&dest.put_child(key, Common::PropertyTree(&dest)));
-        convertPtreeToPropertyTree(child_tree, *new_tree);
-      }
-    }
-  }
-}
-
 } // namespace Wge

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -39,7 +39,8 @@ namespace Wge {
 constexpr size_t variable_key_with_macro_size = 100;
 constexpr int max_capture_size = 100;
 
-Transaction::Transaction(const Engine& engin) : engine_(engin) {
+Transaction::Transaction(const Engine& engin, std::shared_ptr<Common::PropertyStore> property_store)
+    : engine_(engin), property_store_(std::move(property_store)) {
   for (auto& [ns, size] : engine_.getTxVariableIndexSize()) {
     auto& tx_var_info = tx_variables_[ns];
     tx_var_info.variables_.reserve(size + variable_key_with_macro_size);

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -34,6 +34,7 @@
 #include <boost/unordered/unordered_flat_set.hpp>
 
 #include "common/evaluate_result.h"
+#include "common/property_store.h"
 #include "common/property_tree.h"
 #include "common/ragel/json.h"
 #include "common/ragel/multi_part.h"
@@ -63,7 +64,7 @@ class Transaction final {
   friend class Engine;
 
 protected:
-  Transaction(const Engine& engin);
+  Transaction(const Engine& engin, std::shared_ptr<Common::PropertyStore> property_store);
 
 public:
   // The connection info
@@ -598,6 +599,13 @@ public:
     return string_pool_.front();
   }
 
+  const Common::PropertyTree* propertyTree() {
+    if (property_store_) {
+      return &property_store_->getPropertyTree();
+    }
+    return nullptr;
+  }
+
 private:
   void initUniqueId() const;
   inline bool process(RulePhaseType phase);
@@ -682,6 +690,7 @@ private:
   AdditionalCondCallback additional_cond_;
   void* additional_cond_user_data_;
   std::forward_list<std::string> string_pool_;
+  std::shared_ptr<Common::PropertyStore> property_store_;
 };
 
 using TransactionPtr = std::unique_ptr<Transaction>;

--- a/src/variable/ptree.cc
+++ b/src/variable/ptree.cc
@@ -27,10 +27,14 @@
 namespace Wge {
 namespace Variable {
 void Variable::PTree::evaluate(Transaction& t, Common::EvaluateResults& result) const {
-  if (paths_.empty()) {
-    evaluateNode(&t.getEngine().propertyTree(), result);
-  } else {
-    evaluateNode(&t.getEngine().propertyTree(), paths_, 0, result);
+  const Common::PropertyTree* root = t.propertyTree();
+  assert(root != nullptr);
+  if (root) {
+    if (paths_.empty()) {
+      evaluateNode(root, result);
+    } else {
+      evaluateNode(root, paths_, 0, result);
+    }
   }
 }
 

--- a/test/integration/01_variable.cc
+++ b/test/integration/01_variable.cc
@@ -845,7 +845,7 @@ TEST_F(VariableTest, PTREE) {
 })";
 
   Engine engine(spdlog::level::off);
-  auto pt_result = engine.propertyTree(json);
+  auto pt_result = engine.updatePropertyStore(json);
   ASSERT_TRUE(pt_result.has_value());
   engine.init();
   auto t = engine.makeTransaction();
@@ -987,7 +987,7 @@ TEST_F(VariableTest, MATCHED_OPTREE) {
 })";
 
   Engine engine(spdlog::level::off);
-  auto pt_result = engine.propertyTree(json);
+  auto pt_result = engine.updatePropertyStore(json);
   ASSERT_TRUE(pt_result.has_value());
   engine.init();
   auto t = engine.makeTransaction();
@@ -996,7 +996,7 @@ TEST_F(VariableTest, MATCHED_OPTREE) {
   // config.server_list[].port../host
   {
     auto& matched_optree =
-        engine.propertyTree().get_child("config.server_list").front().second.get_child("port");
+        t->propertyTree()->get_child("config.server_list").front().second.get_child("port");
     EXPECT_EQ(std::get<int64_t>(matched_optree.data()), 8080);
     t->pushMatchedOPTree(-1, static_cast<const Common::PropertyTree*>(&matched_optree));
     Variable::MatchedOPTree var("../host", false, false, "");
@@ -1008,8 +1008,8 @@ TEST_F(VariableTest, MATCHED_OPTREE) {
 
   // config.server_list[].tags[]../../domain.name
   {
-    auto& matched_optree = engine.propertyTree()
-                               .get_child("config.server_list")
+    auto& matched_optree = t->propertyTree()
+                               ->get_child("config.server_list")
                                .back()
                                .second.get_child("tags")
                                .front()
@@ -1059,7 +1059,7 @@ TEST_F(VariableTest, MATCHED_VPTREE) {
 })";
 
   Engine engine(spdlog::level::off);
-  auto pt_result = engine.propertyTree(json);
+  auto pt_result = engine.updatePropertyStore(json);
   ASSERT_TRUE(pt_result.has_value());
   engine.init();
   auto t = engine.makeTransaction();
@@ -1068,7 +1068,7 @@ TEST_F(VariableTest, MATCHED_VPTREE) {
   // config.server_list[].port../host
   {
     auto& matched_vptree =
-        engine.propertyTree().get_child("config.server_list").front().second.get_child("port");
+        t->propertyTree()->get_child("config.server_list").front().second.get_child("port");
     EXPECT_EQ(std::get<int64_t>(matched_vptree.data()), 8080);
     t->pushMatchedVPTree(-1, static_cast<const Common::PropertyTree*>(&matched_vptree));
     Variable::MatchedVPTree var("../host", false, false, "");
@@ -1080,8 +1080,8 @@ TEST_F(VariableTest, MATCHED_VPTREE) {
 
   // config.server_list[].tags[]../../domain.name
   {
-    auto& matched_vptree = engine.propertyTree()
-                               .get_child("config.server_list")
+    auto& matched_vptree = t->propertyTree()
+                               ->get_child("config.server_list")
                                .back()
                                .second.get_child("tags")
                                .front()

--- a/test/integration/04_rule_evaluate_logic_test.cc
+++ b/test/integration/04_rule_evaluate_logic_test.cc
@@ -557,7 +557,7 @@ TEST(RuleEvaluateLogicTest, MachedVPTree) {
   engine.init();
   ASSERT_TRUE(result.has_value());
 
-  auto pt_result = engine.propertyTree(json);
+  auto pt_result = engine.updatePropertyStore(json);
   ASSERT_TRUE(pt_result.has_value());
 
   auto t = engine.makeTransaction();
@@ -612,7 +612,7 @@ TEST(RuleEvaluateLogicTest, MachedOPTree) {
   engine.init();
   ASSERT_TRUE(result.has_value());
 
-  auto pt_result = engine.propertyTree(json);
+  auto pt_result = engine.updatePropertyStore(json);
   ASSERT_TRUE(pt_result.has_value());
 
   auto t = engine.makeTransaction();


### PR DESCRIPTION
This commit introduces the ability to dynamically update the property store in the engine.
Each transaction holds a snapshot of the property store, and when a new transaction is created, it gets the latest property store from the engine.