### PR TITLE
refactor(operator): improve code reuse

### DIFF
--- a/src/operator/contains.h
+++ b/src/operator/contains.h
@@ -37,60 +37,13 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (!macro_)
-      [[likely]] {
-        if (IS_STRING_VIEW_VARIANT(operand))
-          [[likely]] {
-            bool matched =
-                std::get<std::string_view>(operand).find(literal_value_) != std::string_view::npos;
-            if (matched) {
-              results.emplace_back(true, literal_value_);
-            } else {
-              results.emplace_back(false);
-            }
-          }
-        else {
-          results.emplace_back(false);
-        }
-      }
-    else {
-      Common::EvaluateResults macro_result;
-      macro_->evaluate(t, macro_result);
-      if (macro_result.empty()) {
-        results.emplace_back(empty_match_);
-        return;
-      }
-
-      for (const auto& right_operand : macro_result) {
-        if (IS_STRING_VIEW_VARIANT(right_operand.variant_))
-          [[likely]] {
-            if (!IS_STRING_VIEW_VARIANT(operand))
-              [[unlikely]] {
-                results.emplace_back(false);
-                continue;
-              }
-
-            results.emplace_back(std::get<std::string_view>(operand).find(
-                                     std::get<std::string_view>(right_operand.variant_)) !=
-                                     std::string_view::npos,
-                                 "", right_operand.ptree_node_);
-            WGE_LOG_TRACE([&]() {
-              std::string sub_name;
-              if (!right_operand.variable_sub_name_.empty()) {
-                sub_name = std::format("\"{}\":", right_operand.variable_sub_name_);
-              }
-              return std::format("{} @{} {}{} => {}", std::get<std::string_view>(operand), name_,
-                                 sub_name, std::get<std::string_view>(right_operand.variant_),
-                                 results.back().matched_);
-            }());
-          }
-        else if (IS_EMPTY_VARIANT(right_operand.variant_)) {
-          results.emplace_back(empty_match_);
-        } else {
-          results.emplace_back(false);
-        }
-      }
-    }
+    performComparison<std::string_view, std::string_view>(
+        t, operand, literal_value_, results,
+        [](Transaction& t, std::string_view left_operand, std::string_view right_operand,
+           Results& results, void*) {
+          results.emplace_back(left_operand.find(right_operand) != std::string_view::npos,
+                               right_operand);
+        });
   }
 };
 } // namespace Operator

--- a/src/operator/detect_xss.cc
+++ b/src/operator/detect_xss.cc
@@ -25,19 +25,13 @@
 namespace Wge {
 namespace Operator {
 void DetectXSS::evaluate(Transaction& t, const Common::Variant& operand, Results& results) const {
-  if (!IS_STRING_VIEW_VARIANT(operand))
-    [[unlikely]] {
-      results.emplace_back(false);
-      return;
-    }
-
-  std::string_view data = std::get<std::string_view>(operand);
-  bool is_xss = libinjection_xss(data.data(), data.size()) != 0;
-  if (is_xss) {
-    results.emplace_back(true, t.internString({data.data(), data.size()}));
-  } else {
-    results.emplace_back(false);
-  }
+  performComparison<std::string_view, std::string_view>(
+      t, operand, "", results,
+      [](Transaction& t, std::string_view left_operand, std::string_view right_operand,
+         Results& results, void*) {
+        bool is_xss = libinjection_xss(left_operand.data(), left_operand.size()) != 0;
+        results.emplace_back(is_xss, left_operand);
+      });
 }
 } // namespace Operator
 } // namespace Wge

--- a/src/operator/ends_with.h
+++ b/src/operator/ends_with.h
@@ -37,53 +37,11 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (!macro_)
-      [[likely]] {
-        if (IS_STRING_VIEW_VARIANT(operand))
-          [[likely]] {
-            results.emplace_back(std::get<std::string_view>(operand).ends_with(literal_value_));
-          }
-        else {
-          results.emplace_back(false);
-        }
-      }
-    else {
-      Common::EvaluateResults macro_result;
-      macro_->evaluate(t, macro_result);
-      if (macro_result.empty()) {
-        results.emplace_back(empty_match_);
-        return;
-      }
-
-      for (const auto& right_operand : macro_result) {
-        if (IS_STRING_VIEW_VARIANT(right_operand.variant_))
-          [[likely]] {
-            if (!IS_STRING_VIEW_VARIANT(operand))
-              [[unlikely]] {
-                results.emplace_back(false);
-                continue;
-              }
-
-            results.emplace_back(std::get<std::string_view>(operand).ends_with(
-                                     std::get<std::string_view>(right_operand.variant_)),
-                                 "", right_operand.ptree_node_);
-            WGE_LOG_TRACE([&]() {
-              std::string sub_name;
-              if (!right_operand.variable_sub_name_.empty()) {
-                sub_name = std::format("\"{}\":", right_operand.variable_sub_name_);
-              }
-              return std::format("{} @{} {}{} => {}", std::get<std::string_view>(operand), name_,
-                                 sub_name, std::get<std::string_view>(right_operand.variant_),
-                                 results.back().matched_);
-            }());
-          }
-        else if (IS_EMPTY_VARIANT(right_operand.variant_)) {
-          results.emplace_back(empty_match_);
-        } else {
-          results.emplace_back(false);
-        }
-      }
-    }
+    performComparison<std::string_view, std::string_view>(
+        t, operand, literal_value_, results,
+        [](Transaction& t, std::string_view left_operand, std::string_view right_operand,
+           Results& results,
+           void*) { results.emplace_back(left_operand.ends_with(right_operand)); });
   }
 };
 } // namespace Operator

--- a/src/operator/eq.h
+++ b/src/operator/eq.h
@@ -43,54 +43,11 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (!macro_)
-      [[likely]] {
-        if (IS_INT_VARIANT(operand))
-          [[likely]] {
-            int64_t left_value = std::get<int64_t>(operand);
-            results.emplace_back(left_value == right_value_);
-          }
-        else {
-          results.emplace_back(false);
-        }
-      }
-    else {
-      Common::EvaluateResults macro_result;
-      macro_->evaluate(t, macro_result);
-      if (macro_result.empty()) {
-        results.emplace_back(empty_match_);
-        return;
-      }
-
-      for (const auto& right_operand : macro_result) {
-        if (IS_INT_VARIANT(right_operand.variant_))
-          [[likely]] {
-            if (!IS_INT_VARIANT(operand))
-              [[unlikely]] {
-                results.emplace_back(false);
-                continue;
-              }
-
-            results.emplace_back(std::get<int64_t>(operand) ==
-                                     std::get<int64_t>(right_operand.variant_),
-                                 "", right_operand.ptree_node_);
-            WGE_LOG_TRACE([&]() {
-              std::string sub_name;
-              if (!right_operand.variable_sub_name_.empty()) {
-                sub_name = std::format("\"{}\":", right_operand.variable_sub_name_);
-              }
-              return std::format("{} @{} {}{} => {}", std::get<int64_t>(operand), name_, sub_name,
-                                 std::get<int64_t>(right_operand.variant_),
-                                 results.back().matched_);
-            }());
-          }
-        else if (IS_EMPTY_VARIANT(right_operand.variant_)) {
-          results.emplace_back(empty_match_);
-        } else {
-          results.emplace_back(false);
-        }
-      }
-    }
+    performComparison<int64_t, int64_t>(
+        t, operand, right_value_, results,
+        [](Transaction& t, int64_t left_operand, int64_t right_operand, Results& results, void*) {
+          results.emplace_back(left_operand == right_operand);
+        });
   }
 
 private:

--- a/src/operator/gt.h
+++ b/src/operator/gt.h
@@ -38,54 +38,11 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (!macro_)
-      [[likely]] {
-        if (IS_INT_VARIANT(operand))
-          [[likely]] {
-            int64_t left_value = std::get<int64_t>(operand);
-            results.emplace_back(left_value > right_value_);
-          }
-        else {
-          results.emplace_back(false);
-        }
-      }
-    else {
-      Common::EvaluateResults macro_result;
-      macro_->evaluate(t, macro_result);
-      if (macro_result.empty()) {
-        results.emplace_back(empty_match_);
-        return;
-      }
-
-      for (const auto& right_operand : macro_result) {
-        if (IS_INT_VARIANT(right_operand.variant_))
-          [[likely]] {
-            if (!IS_INT_VARIANT(operand))
-              [[unlikely]] {
-                results.emplace_back(false);
-                continue;
-              }
-
-            results.emplace_back(std::get<int64_t>(operand) >
-                                     std::get<int64_t>(right_operand.variant_),
-                                 "", right_operand.ptree_node_);
-            WGE_LOG_TRACE([&]() {
-              std::string sub_name;
-              if (!right_operand.variable_sub_name_.empty()) {
-                sub_name = std::format("\"{}\":", right_operand.variable_sub_name_);
-              }
-              return std::format("{} @{} {}{} => {}", std::get<int64_t>(operand), name_, sub_name,
-                                 std::get<int64_t>(right_operand.variant_),
-                                 results.back().matched_);
-            }());
-          }
-        else if (IS_EMPTY_VARIANT(right_operand.variant_)) {
-          results.emplace_back(empty_match_);
-        } else {
-          results.emplace_back(false);
-        }
-      }
-    }
+    performComparison<int64_t, int64_t>(
+        t, operand, right_value_, results,
+        [](Transaction& t, int64_t left_operand, int64_t right_operand, Results& results, void*) {
+          results.emplace_back(left_operand > right_operand);
+        });
   }
 
 private:

--- a/src/operator/le.h
+++ b/src/operator/le.h
@@ -38,54 +38,11 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (!macro_)
-      [[likely]] {
-        if (IS_INT_VARIANT(operand))
-          [[likely]] {
-            int64_t left_value = std::get<int64_t>(operand);
-            results.emplace_back(left_value <= right_value_);
-          }
-        else {
-          results.emplace_back(false);
-        }
-      }
-    else {
-      Common::EvaluateResults macro_result;
-      macro_->evaluate(t, macro_result);
-      if (macro_result.empty()) {
-        results.emplace_back(empty_match_);
-        return;
-      }
-
-      for (const auto& right_operand : macro_result) {
-        if (IS_INT_VARIANT(right_operand.variant_))
-          [[likely]] {
-            if (!IS_INT_VARIANT(operand))
-              [[unlikely]] {
-                results.emplace_back(false);
-                continue;
-              }
-
-            results.emplace_back(std::get<int64_t>(operand) <=
-                                     std::get<int64_t>(right_operand.variant_),
-                                 "", right_operand.ptree_node_);
-            WGE_LOG_TRACE([&]() {
-              std::string sub_name;
-              if (!right_operand.variable_sub_name_.empty()) {
-                sub_name = std::format("\"{}\":", right_operand.variable_sub_name_);
-              }
-              return std::format("{} @{} {}{} => {}", std::get<int64_t>(operand), name_, sub_name,
-                                 std::get<int64_t>(right_operand.variant_),
-                                 results.back().matched_);
-            }());
-          }
-        else if (IS_EMPTY_VARIANT(right_operand.variant_)) {
-          results.emplace_back(empty_match_);
-        } else {
-          results.emplace_back(false);
-        }
-      }
-    }
+    performComparison<int64_t, int64_t>(
+        t, operand, right_value_, results,
+        [](Transaction& t, int64_t left_operand, int64_t right_operand, Results& results, void*) {
+          results.emplace_back(left_operand <= right_operand);
+        });
   }
 
 private:

--- a/src/operator/lt.h
+++ b/src/operator/lt.h
@@ -38,54 +38,11 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (!macro_)
-      [[likely]] {
-        if (IS_INT_VARIANT(operand))
-          [[likely]] {
-            int64_t left_value = std::get<int64_t>(operand);
-            results.emplace_back(left_value < right_value_);
-          }
-        else {
-          results.emplace_back(false);
-        }
-      }
-    else {
-      Common::EvaluateResults macro_result;
-      macro_->evaluate(t, macro_result);
-      if (macro_result.empty()) {
-        results.emplace_back(empty_match_);
-        return;
-      }
-
-      for (const auto& right_operand : macro_result) {
-        if (IS_INT_VARIANT(right_operand.variant_))
-          [[likely]] {
-            if (!IS_INT_VARIANT(operand))
-              [[unlikely]] {
-                results.emplace_back(false);
-                continue;
-              }
-
-            results.emplace_back(std::get<int64_t>(operand) <
-                                     std::get<int64_t>(right_operand.variant_),
-                                 "", right_operand.ptree_node_);
-            WGE_LOG_TRACE([&]() {
-              std::string sub_name;
-              if (!right_operand.variable_sub_name_.empty()) {
-                sub_name = std::format("\"{}\":", right_operand.variable_sub_name_);
-              }
-              return std::format("{} @{} {}{} => {}", std::get<int64_t>(operand), name_, sub_name,
-                                 std::get<int64_t>(right_operand.variant_),
-                                 results.back().matched_);
-            }());
-          }
-        else if (IS_EMPTY_VARIANT(right_operand.variant_)) {
-          results.emplace_back(empty_match_);
-        } else {
-          results.emplace_back(false);
-        }
-      }
-    }
+    performComparison<int64_t, int64_t>(
+        t, operand, right_value_, results,
+        [](Transaction& t, int64_t left_operand, int64_t right_operand, Results& results, void*) {
+          results.emplace_back(left_operand < right_operand);
+        });
   }
 
 private:

--- a/src/operator/streq.h
+++ b/src/operator/streq.h
@@ -41,54 +41,10 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (!macro_)
-      [[likely]] {
-        if (IS_STRING_VIEW_VARIANT(operand))
-          [[likely]] {
-            results.emplace_back(std::get<std::string_view>(operand) == literal_value_);
-          }
-        else {
-          results.emplace_back(false);
-        }
-      }
-    else {
-      Common::EvaluateResults macro_result;
-      macro_->evaluate(t, macro_result);
-      if (macro_result.empty()) {
-        results.emplace_back(empty_match_);
-        return;
-      }
-
-      for (const auto& right_operand : macro_result) {
-        if (IS_STRING_VIEW_VARIANT(right_operand.variant_))
-          [[likely]] {
-            if (!IS_STRING_VIEW_VARIANT(operand))
-              [[unlikely]] {
-                results.emplace_back(false);
-                continue;
-              }
-
-            results.emplace_back(std::get<std::string_view>(operand) ==
-                                     std::get<std::string_view>(right_operand.variant_),
-                                 "", right_operand.ptree_node_);
-
-            WGE_LOG_TRACE([&]() {
-              std::string sub_name;
-              if (!right_operand.variable_sub_name_.empty()) {
-                sub_name = std::format("\"{}\":", right_operand.variable_sub_name_);
-              }
-              return std::format("{} @{} {}{} => {}", std::get<std::string_view>(operand), name_,
-                                 sub_name, std::get<std::string_view>(right_operand.variant_),
-                                 results.back().matched_);
-            }());
-          }
-        else if (IS_EMPTY_VARIANT(right_operand.variant_)) {
-          results.emplace_back(empty_match_);
-        } else {
-          results.emplace_back(false);
-        }
-      }
-    }
+    performComparison<std::string_view, std::string_view>(
+        t, operand, literal_value_, results,
+        [](Transaction& t, std::string_view left_operand, std::string_view right_operand,
+           Results& results, void*) { results.emplace_back(left_operand == right_operand); });
   }
 };
 } // namespace Operator

--- a/src/operator/validate_url_encoding.h
+++ b/src/operator/validate_url_encoding.h
@@ -41,35 +41,33 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (!IS_STRING_VIEW_VARIANT(operand))
-      [[unlikely]] {
-        results.emplace_back(false);
-        return;
-      }
+    performComparison<std::string_view, std::string_view>(
+        t, operand, "", results,
+        [](Transaction& t, std::string_view left_operand, std::string_view right_operand,
+           Results& results, void*) {
+          // Check that after percent character must be two hexadecimal characters.
+          size_t len = left_operand.size();
+          for (size_t i = 0; i < len; ++i) {
+            if (left_operand[i] == '%') {
 
-    // Check that after percent character must be two hexadecimal characters.
-    std::string_view input = std::get<std::string_view>(operand);
-    size_t len = input.size();
-    for (size_t i = 0; i < len; ++i) {
-      if (input[i] == '%') {
+              // If there are less than two characters after '%', it is not a valid URL encoding
+              // (for example, it ends with "%2" or "%") and is considered illegal.
+              if (i + 2 >= len) {
+                results.emplace_back(true);
+                return;
+              }
 
-        // If there are less than two characters after '%', it is not a valid URL encoding (for
-        // example, it ends with "%2" or "%") and is considered illegal.
-        if (i + 2 >= len) {
-          results.emplace_back(true);
-          return;
-        }
+              if (!::isxdigit(left_operand[i + 1]) || !::isxdigit(left_operand[i + 2])) {
+                results.emplace_back(true);
+                return;
+              }
 
-        if (!::isxdigit(input[i + 1]) || !::isxdigit(input[i + 2])) {
-          results.emplace_back(true);
-          return;
-        }
+              i += 2;
+            }
+          }
 
-        i += 2;
-      }
-    }
-
-    results.emplace_back(false);
+          results.emplace_back(false);
+        });
   }
 };
 } // namespace Operator

--- a/src/operator/within.h
+++ b/src/operator/within.h
@@ -67,124 +67,67 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (macro_)
-      [[unlikely]] {
-        Common::EvaluateResults macro_result;
-        macro_->evaluate(t, macro_result);
-        if (macro_result.empty()) {
-          results.emplace_back(empty_match_);
-          return;
-        }
+    performComparison<std::string_view, std::string_view>(
+        t, operand, literal_value_, results,
+        [](Transaction& t, std::string_view left_operand, std::string_view right_operand,
+           Results& results, void* user_data) {
+          const Within* obj = reinterpret_cast<const Within*>(user_data);
 
-        for (const auto& right_operand : macro_result) {
-          if (IS_STRING_VIEW_VARIANT(right_operand.variant_))
-            [[likely]] {
-              if (!IS_STRING_VIEW_VARIANT(operand))
-                [[unlikely]] {
-                  results.emplace_back(false);
-                  continue;
-                }
+          Common::Hyperscan::Scanner* scanner = obj->scanner_.get();
+          std::unique_ptr<Common::Hyperscan::Scanner> macro_scanner;
 
-              // Split the literal value into tokens.
-              std::vector<std::string_view> tokens =
-                  Common::SplitTokens(std::get<std::string_view>(right_operand.variant_));
+          // If there is a macro, expand it and create a scanner.
+          if (scanner == nullptr) {
+            // Split the literal value into tokens.
+            std::vector<std::string_view> tokens = Common::SplitTokens(right_operand);
 
-              // Calculate the order independent hash value of all tokens.
-              int64_t hash = calcOrderIndependentHash(tokens);
+            // Calculate the order independent hash value of all tokens.
+            int64_t hash = calcOrderIndependentHash(tokens);
 
-              // Load the hyperscan database and create a scanner.
-              // We cache the hyperscan database to avoid loading(complie) the same database
-              // multiple times.
-              std::unique_ptr<Common::Hyperscan::Scanner> scanner;
-              database_cache_.access(
-                  hash,
-                  [&](const std::shared_ptr<Common::Hyperscan::HsDataBase>& hs_db) {
-                    scanner = std::make_unique<Common::Hyperscan::Scanner>(hs_db);
-                  },
-                  [&]() {
-                    return std::make_shared<Common::Hyperscan::HsDataBase>(tokens, true, true, true,
-                                                                           false, false);
-                  });
+            // Load the hyperscan database and create a scanner.
+            // We cache the hyperscan database to avoid loading(complie) the same database
+            // multiple times.
+            database_cache_.access(
+                hash,
+                [&](const std::shared_ptr<Common::Hyperscan::HsDataBase>& hs_db) {
+                  macro_scanner = std::make_unique<Common::Hyperscan::Scanner>(hs_db);
+                },
+                [&]() {
+                  return std::make_shared<Common::Hyperscan::HsDataBase>(tokens, true, true, true,
+                                                                         false, false);
+                });
+            scanner = macro_scanner.get();
+          }
 
-              // The hyperscan scanner is thread-safe, so we can use the same scanner for all
-              // transactions.
-              // Actually, the scanner uses a thread-local scratch space to avoid the overhead of
-              // creating a scratch space for each transaction.
-              std::pair<unsigned long long, unsigned long long> result(0, 0);
-              scanner->registMatchCallback(
-                  [](uint64_t id, unsigned long long from, unsigned long long to,
-                     unsigned int flags, void* user_data) -> int {
-                    std::pair<unsigned long long, unsigned long long>* result =
-                        static_cast<std::pair<unsigned long long, unsigned long long>*>(user_data);
-                    result->first = from;
-                    result->second = to;
-                    return 1;
-                  },
-                  &result);
-              std::string_view left_operand_str = std::get<std::string_view>(operand);
-              scanner->blockScan(left_operand_str);
+          // The hyperscan scanner is thread-safe, so we can use the same scanner for all
+          // transactions. Actually, the scanner uses a thread-local scratch space to avoid the
+          // overhead of creating a scratch space for each transaction.
+          std::pair<unsigned long long, unsigned long long> result(0, 0);
+          scanner->registMatchCallback(
+              [](uint64_t id, unsigned long long from, unsigned long long to, unsigned int flags,
+                 void* user_data) -> int {
+                std::pair<unsigned long long, unsigned long long>* result =
+                    static_cast<std::pair<unsigned long long, unsigned long long>*>(user_data);
+                result->first = from;
+                result->second = to;
+                return 1;
+              },
+              &result);
 
-              bool matched = result.first != result.second;
-              if (matched) {
-                results.emplace_back(true,
-                                     std::string_view{left_operand_str.data() + result.first,
-                                                      result.second - result.first},
-                                     right_operand.ptree_node_);
-              } else {
-                results.emplace_back(false);
-              }
-
-              WGE_LOG_TRACE([&]() {
-                std::string sub_name;
-                if (!right_operand.variable_sub_name_.empty()) {
-                  sub_name = std::format("\"{}\":", right_operand.variable_sub_name_);
-                }
-                return std::format("{} @{} {}{} => {}", std::get<std::string_view>(operand), name_,
-                                   sub_name, std::get<std::string_view>(right_operand.variant_),
-                                   results.back().matched_);
-              }());
-            }
-          else if (IS_EMPTY_VARIANT(right_operand.variant_)) {
-            results.emplace_back(empty_match_);
+          scanner->blockScan(left_operand);
+          bool matched = result.first != result.second;
+          if (matched) {
+            results.emplace_back(true, std::string_view{left_operand.data() + result.first,
+                                                        result.second - result.first});
           } else {
             results.emplace_back(false);
           }
-        }
-      }
-    else {
-      if (IS_STRING_VIEW_VARIANT(operand)) {
-        // The hyperscan scanner is thread-safe, so we can use the same scanner for all
-        // transactions. Actually, the scanner uses a thread-local scratch space to avoid the
-        // overhead of creating a scratch space for each transaction.
-        std::pair<unsigned long long, unsigned long long> result(0, 0);
-        scanner_->registMatchCallback(
-            [](uint64_t id, unsigned long long from, unsigned long long to, unsigned int flags,
-               void* user_data) -> int {
-              std::pair<unsigned long long, unsigned long long>* result =
-                  static_cast<std::pair<unsigned long long, unsigned long long>*>(user_data);
-              result->first = from;
-              result->second = to;
-              return 1;
-            },
-            &result);
-        std::string_view operand_str = std::get<std::string_view>(operand);
-        scanner_->blockScan(operand_str);
-
-        bool matched = result.first != result.second;
-        if (matched) {
-          results.emplace_back(true, std::string_view{operand_str.data() + result.first,
-                                                      result.second - result.first});
-        } else {
-          results.emplace_back(false);
-        }
-      } else {
-        results.emplace_back(false);
-      }
-    }
+        },
+        const_cast<Within*>(this));
   }
 
 private:
-  int64_t calcOrderIndependentHash(const std::vector<std::string_view>& tokens) const {
+  static int64_t calcOrderIndependentHash(const std::vector<std::string_view>& tokens) {
     int64_t hash = 0;
     std::vector<size_t> token_hashes;
     for (auto token : tokens) {

--- a/src/operator/xor.h
+++ b/src/operator/xor.h
@@ -43,52 +43,11 @@ public:
 
 public:
   void evaluate(Transaction& t, const Common::Variant& operand, Results& results) const override {
-    if (!macro_)
-      [[likely]] {
-        if (IS_INT_VARIANT(operand)) {
-          int64_t left_value = std::get<int64_t>(operand);
-          results.emplace_back((left_value ^ right_value_) != 0);
-        } else {
-          results.emplace_back(false);
-        }
-      }
-    else {
-      Common::EvaluateResults macro_result;
-      macro_->evaluate(t, macro_result);
-      if (macro_result.empty()) {
-        results.emplace_back(empty_match_);
-        return;
-      }
-
-      for (const auto& right_operand : macro_result) {
-        if (IS_INT_VARIANT(right_operand.variant_))
-          [[likely]] {
-            if (!IS_INT_VARIANT(operand))
-              [[unlikely]] {
-                results.emplace_back(false);
-                continue;
-              }
-
-            results.emplace_back(
-                (std::get<int64_t>(operand) ^ std::get<int64_t>(right_operand.variant_)) != 0, "",
-                right_operand.ptree_node_);
-            WGE_LOG_TRACE([&]() {
-              std::string sub_name;
-              if (!right_operand.variable_sub_name_.empty()) {
-                sub_name = std::format("\"{}\":", right_operand.variable_sub_name_);
-              }
-              return std::format("{} @{} {}{} => {}", std::get<int64_t>(operand), name_, sub_name,
-                                 std::get<int64_t>(right_operand.variant_),
-                                 results.back().matched_);
-            }());
-          }
-        else if (IS_EMPTY_VARIANT(right_operand.variant_)) {
-          results.emplace_back(empty_match_);
-        } else {
-          results.emplace_back(false);
-        }
-      }
-    }
+    performComparison<int64_t, int64_t>(
+        t, operand, right_value_, results,
+        [](Transaction& t, int64_t left_operand, int64_t right_operand, Results& results, void*) {
+          results.emplace_back((left_operand ^ right_operand) != 0);
+        });
   }
 
 private:


### PR DESCRIPTION
Extract common comparison logic to base class
- Add performComparison template method to OperatorBase
- Simplify macro evaluation and type checking logic in derived operators