### PR TITLE
feat(variable): support variable subname macro

### DIFF
--- a/src/antlr4/SecLangLexer.g4
+++ b/src/antlr4/SecLangLexer.g4
@@ -485,8 +485,11 @@ ModeSecRuleVariableName_VAR_COUNT: AND -> type(VAR_COUNT);
 ModeSecRuleVariableName_VAR_NOT: NOT -> type(NOT);
 ModeSecRuleVariableName_LEFT_BRACKET:
 	LEFT_BRACKET -> type(LEFT_BRACKET);
-ModeSecRuleVariableName_RIGHT_BRACKET:
-	RIGHT_BRACKET -> type(RIGHT_BRACKET), popMode;
+ModeSecRuleVariableName_RIGHT_BRACKET_OTHERS:
+	RIGHT_BRACKET {modeStack.size() > 1 && modeStack[modeStack.size() - 1] != ModeSecRule}? -> type(
+		RIGHT_BRACKET), popMode;
+ModeSecRuleVariableName_RIGHT_BRACKET_SECRULE:
+	RIGHT_BRACKET -> type(RIGHT_BRACKET);
 
 mode ModeSecRuleVariableNamePtree;
 ModeSecRuleVariableNamePtree_WS:
@@ -525,9 +528,14 @@ ModeSecRuleVariableNamePtreePath_RIGHT_SQUARE:
 	RIGHT_SQUARE -> type(RIGHT_SQUARE);
 ModeSecRuleVariableNamePtreePath_LEFT_BRACKET:
 	LEFT_BRACKET -> type(LEFT_BRACKET), pushMode(ModeSecRuleVariableNamePtreeRightBracketClose);
-ModeSecRuleVariableNamePtreePath_RIGHT_BRACKET:
-	// Exit: VariableNamePtree -> VariableName -> Variable
-	RIGHT_BRACKET -> type(RIGHT_BRACKET), popMode, popMode, popMode;
+ModeSecRuleVariableNamePtreePath_RIGHT_BRACKET_OPERATOR_VALUE:
+	// Exit: VariableNamePtree -> VariableName -> OperatorValue
+	RIGHT_BRACKET {modeStack.size() > 3 && modeStack[modeStack.size() - 3] == ModeSecRuleOperatorValue
+		}? -> type(RIGHT_BRACKET), popMode, popMode, popMode;
+ModeSecRuleVariableNamePtreePath_RIGHT_BRACKET_VARIABLE:
+	// Exit: VariableNamePtree -> VariableName
+	RIGHT_BRACKET {modeStack.size() > 3 && modeStack[modeStack.size() - 3] == ModeSecRule
+		}? -> type(RIGHT_BRACKET), popMode, popMode;
 ModeSecRuleVariableNamePtreePath_PIPE:
 	// Exit: VariableNamePtree -> VariableName
 	PIPE -> type(PIPE), popMode, popMode;
@@ -567,6 +575,8 @@ ModeSecRuleVariableSubName_VAR_SUB_NAME:
 ModeSecRuleVariableSubName_SINGLE_QUOTE:
 	SINGLE_QUOTE -> type(SINGLE_QUOTE), popMode, pushMode(ModeSecRuleVariableSubNameWithSingleQuote)
 		;
+ModeSecRuleVariableSubName_PER_CENT:
+	PER_CENT -> type(PER_CENT), popMode;
 
 mode ModeSecRuleVariableSubNameWithSingleQuote;
 ModeSecRuleVariableSubNameWithSingleQuote_SINGLE_QUOTE:

--- a/src/antlr4/SecLangParser.g4
+++ b/src/antlr4/SecLangParser.g4
@@ -241,6 +241,9 @@ variable_args:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_args_combined_size:
@@ -248,6 +251,9 @@ variable_args_combined_size:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_args_get:
@@ -255,6 +261,9 @@ variable_args_get:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_args_get_names:
@@ -262,6 +271,9 @@ variable_args_get_names:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_args_names:
@@ -269,6 +281,9 @@ variable_args_names:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_args_post:
@@ -276,6 +291,9 @@ variable_args_post:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_args_post_names:
@@ -283,6 +301,9 @@ variable_args_post_names:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_auth_type:
@@ -290,6 +311,9 @@ variable_auth_type:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_duration:
@@ -297,6 +321,9 @@ variable_duration:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_env:
@@ -304,6 +331,9 @@ variable_env:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_files:
@@ -311,6 +341,9 @@ variable_files:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_files_combined_size:
@@ -318,6 +351,9 @@ variable_files_combined_size:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_files_names:
@@ -325,6 +361,9 @@ variable_files_names:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_full_request:
@@ -332,6 +371,9 @@ variable_full_request:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_full_request_length:
@@ -339,6 +381,9 @@ variable_full_request_length:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_files_sizes:
@@ -346,6 +391,9 @@ variable_files_sizes:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_files_tmpnames:
@@ -353,6 +401,9 @@ variable_files_tmpnames:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_files_tmp_content:
@@ -360,6 +411,9 @@ variable_files_tmp_content:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_geo:
@@ -367,6 +421,9 @@ variable_geo:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_highest_severity:
@@ -374,6 +431,9 @@ variable_highest_severity:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_inbound_data_error:
@@ -381,6 +441,9 @@ variable_inbound_data_error:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_matched_var:
@@ -388,6 +451,9 @@ variable_matched_var:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_matched_vars:
@@ -395,6 +461,9 @@ variable_matched_vars:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_matched_var_name:
@@ -402,6 +471,9 @@ variable_matched_var_name:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_matched_vars_names:
@@ -409,6 +481,9 @@ variable_matched_vars_names:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_modsec_build:
@@ -416,6 +491,9 @@ variable_modsec_build:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_msc_pcre_limits_exceeded:
@@ -423,6 +501,9 @@ variable_msc_pcre_limits_exceeded:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_crlf_lf_lines:
@@ -430,6 +511,9 @@ variable_multipart_crlf_lf_lines:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_filename:
@@ -437,6 +521,9 @@ variable_multipart_filename:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_name:
@@ -444,6 +531,9 @@ variable_multipart_name:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_part_headers:
@@ -451,6 +541,9 @@ variable_multipart_part_headers:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_strict_error:
@@ -458,6 +551,9 @@ variable_multipart_strict_error:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_unmatched_boundary:
@@ -465,6 +561,9 @@ variable_multipart_unmatched_boundary:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_outbound_data_error:
@@ -472,6 +571,9 @@ variable_outbound_data_error:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_path_info:
@@ -479,6 +581,9 @@ variable_path_info:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_query_string:
@@ -486,6 +591,9 @@ variable_query_string:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_remote_addr:
@@ -493,6 +601,9 @@ variable_remote_addr:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_remote_host:
@@ -500,6 +611,9 @@ variable_remote_host:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_remote_port:
@@ -507,6 +621,9 @@ variable_remote_port:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_remote_user:
@@ -514,6 +631,9 @@ variable_remote_user:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_reqbody_error:
@@ -521,6 +641,9 @@ variable_reqbody_error:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_reqbody_error_msg:
@@ -528,6 +651,9 @@ variable_reqbody_error_msg:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_reqbody_processor:
@@ -535,6 +661,9 @@ variable_reqbody_processor:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_basename:
@@ -542,6 +671,9 @@ variable_request_basename:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_body:
@@ -549,6 +681,9 @@ variable_request_body:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_body_length:
@@ -556,6 +691,9 @@ variable_request_body_length:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_cookies:
@@ -563,6 +701,9 @@ variable_request_cookies:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_cookies_names:
@@ -570,6 +711,9 @@ variable_request_cookies_names:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_filename:
@@ -577,6 +721,9 @@ variable_request_filename:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_headers:
@@ -584,6 +731,9 @@ variable_request_headers:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_headers_names:
@@ -591,6 +741,9 @@ variable_request_headers_names:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_line:
@@ -598,6 +751,9 @@ variable_request_line:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_method:
@@ -605,6 +761,9 @@ variable_request_method:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_protocol:
@@ -612,6 +771,9 @@ variable_request_protocol:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_uri:
@@ -619,6 +781,9 @@ variable_request_uri:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_request_uri_raw:
@@ -626,6 +791,9 @@ variable_request_uri_raw:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_response_body:
@@ -633,6 +801,9 @@ variable_response_body:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_response_content_length:
@@ -640,6 +811,9 @@ variable_response_content_length:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_response_content_type:
@@ -647,6 +821,9 @@ variable_response_content_type:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_response_headers:
@@ -654,6 +831,9 @@ variable_response_headers:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_response_headers_names:
@@ -661,6 +841,9 @@ variable_response_headers_names:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_response_protocol:
@@ -668,6 +851,9 @@ variable_response_protocol:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_response_status:
@@ -675,6 +861,9 @@ variable_response_status:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_rule:
@@ -682,6 +871,9 @@ variable_rule:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_server_addr:
@@ -689,6 +881,9 @@ variable_server_addr:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_server_name:
@@ -696,6 +891,9 @@ variable_server_name:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_server_port:
@@ -703,6 +901,9 @@ variable_server_port:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_session:
@@ -710,6 +911,9 @@ variable_session:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_sessionid:
@@ -717,6 +921,9 @@ variable_sessionid:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_status_line:
@@ -724,6 +931,9 @@ variable_status_line:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_time:
@@ -731,6 +941,9 @@ variable_time:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_time_day:
@@ -738,6 +951,9 @@ variable_time_day:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_time_epoch:
@@ -745,6 +961,9 @@ variable_time_epoch:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_time_hour:
@@ -752,6 +971,9 @@ variable_time_hour:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_time_min:
@@ -759,6 +981,9 @@ variable_time_min:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_time_mon:
@@ -766,6 +991,9 @@ variable_time_mon:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_time_sec:
@@ -773,6 +1001,9 @@ variable_time_sec:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_time_wday:
@@ -780,6 +1011,9 @@ variable_time_wday:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_time_year:
@@ -787,6 +1021,9 @@ variable_time_year:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_tx:
@@ -794,6 +1031,9 @@ variable_tx:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_unique_id:
@@ -801,6 +1041,9 @@ variable_unique_id:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_urlencoded_error:
@@ -808,6 +1051,9 @@ variable_urlencoded_error:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_userid:
@@ -815,6 +1061,9 @@ variable_userid:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_webappid:
@@ -822,6 +1071,9 @@ variable_webappid:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_xml:
@@ -829,6 +1081,9 @@ variable_xml:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_reqbody_processor_error:
@@ -836,6 +1091,9 @@ variable_reqbody_processor_error:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_boundary_quoted:
@@ -843,6 +1101,9 @@ variable_multipart_boundary_quoted:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_boundary_whitespace:
@@ -850,6 +1111,9 @@ variable_multipart_boundary_whitespace:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_data_before:
@@ -857,6 +1121,9 @@ variable_multipart_data_before:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_data_after:
@@ -864,6 +1131,9 @@ variable_multipart_data_after:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_header_folding:
@@ -871,6 +1141,9 @@ variable_multipart_header_folding:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_lf_line:
@@ -878,6 +1151,9 @@ variable_multipart_lf_line:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_missing_semicolon:
@@ -885,6 +1161,9 @@ variable_multipart_missing_semicolon:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_invalid_quoting:
@@ -892,6 +1171,9 @@ variable_multipart_invalid_quoting:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_invalid_part:
@@ -899,6 +1181,9 @@ variable_multipart_invalid_part:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_invalid_header_folding:
@@ -906,6 +1191,9 @@ variable_multipart_invalid_header_folding:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_multipart_file_limit_exceeded:
@@ -913,6 +1201,9 @@ variable_multipart_file_limit_exceeded:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_global:
@@ -920,6 +1211,9 @@ variable_global:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_resource:
@@ -927,6 +1221,9 @@ variable_resource:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_ip:
@@ -934,6 +1231,9 @@ variable_ip:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_user:
@@ -941,6 +1241,9 @@ variable_user:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 extension_variable:
@@ -966,6 +1269,9 @@ variable_gtx:
 		(COLON | DOT) (
 			STRING
 			| (SINGLE_QUOTE STRING SINGLE_QUOTE)
+			| (
+				PER_CENT LEFT_BRACKET variable RIGHT_BRACKET
+			)
 		)
 	)?;
 variable_matched_vptree:

--- a/src/variable/args_combined_size.h
+++ b/src/variable/args_combined_size.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ArgsCombinedSize final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ArgsCombinedSize(std::string&& sub_name, bool is_not, bool is_counter,
                    std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ArgsCombinedSize(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                   bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/args_get_names.h
+++ b/src/variable/args_get_names.h
@@ -32,35 +32,14 @@ public:
                std::string_view curr_rule_file_path)
       : ArgsGetBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
-protected:
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& query_params = t.getRequestLineInfo().query_params_.getLinked();
-    for (auto& elem : query_params) {
-      if (!hasExceptVariable(t, main_name_, elem.first))
-        [[likely]] { result.emplace_back(elem.first, elem.first); }
-    }
-  }
+  ArgsGetNames(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+               std::string_view curr_rule_file_path)
+      : ArgsGetBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& query_params_map = t.getRequestLineInfo().query_params_.get();
-        auto range = query_params_map.equal_range(sub_name_);
-        for (auto iter = range.first; iter != range.second; ++iter) {
-          result.emplace_back(iter->first);
-        }
-      }
-    else {
-      auto& query_params = t.getRequestLineInfo().query_params_.getLinked();
-      for (auto& elem : query_params) {
-        if (!hasExceptVariable(t, main_name_, elem.first))
-          [[likely]] {
-            if (match(elem.first)) {
-              result.emplace_back(elem.first, elem.first);
-            }
-          }
-      }
-    }
+protected:
+  void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                     std::string_view value) const override {
+    result.emplace_back(key, key);
   }
 };
 } // namespace Variable

--- a/src/variable/args_names.h
+++ b/src/variable/args_names.h
@@ -32,57 +32,14 @@ public:
             std::string_view curr_rule_file_path)
       : ArgsBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
+  ArgsNames(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+            std::string_view curr_rule_file_path)
+      : ArgsBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
+
 protected:
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& line_query_params = t.getRequestLineInfo().query_params_.getLinked();
-    auto& body_query_params = getBodyQueryParams(t);
-
-    for (auto& elem : line_query_params) {
-      if (!hasExceptVariable(t, main_name_, elem.first))
-        [[likely]] { result.emplace_back(elem.first, elem.first); }
-    }
-    for (auto& elem : body_query_params) {
-      if (!hasExceptVariable(t, main_name_, elem.first))
-        [[likely]] { result.emplace_back(elem.first, elem.first); }
-    }
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& line_query_params_map = t.getRequestLineInfo().query_params_.get();
-        auto& body_query_params_map = getBodyQueryParamsMap(t);
-
-        auto range = line_query_params_map.equal_range(sub_name_);
-        for (auto iter = range.first; iter != range.second; ++iter) {
-          result.emplace_back(iter->first);
-        }
-        auto range2 = body_query_params_map.equal_range(sub_name_);
-        for (auto iter = range2.first; iter != range2.second; ++iter) {
-          result.emplace_back(iter->first);
-        }
-      }
-    else {
-      auto& line_query_params = t.getRequestLineInfo().query_params_.getLinked();
-      auto& body_query_params = getBodyQueryParams(t);
-
-      for (auto& elem : line_query_params) {
-        if (!hasExceptVariable(t, main_name_, elem.first))
-          [[likely]] {
-            if (match(elem.first)) {
-              result.emplace_back(elem.first, elem.first);
-            }
-          }
-      }
-      for (auto& elem : body_query_params) {
-        if (!hasExceptVariable(t, main_name_, elem.first))
-          [[likely]] {
-            if (match(elem.first)) {
-              result.emplace_back(elem.first, elem.first);
-            }
-          }
-      }
-    }
+  void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                     std::string_view value) const override {
+    result.emplace_back(key, key);
   }
 };
 } // namespace Variable

--- a/src/variable/args_post.h
+++ b/src/variable/args_post.h
@@ -33,6 +33,14 @@ public:
                std::string_view curr_rule_file_path)
       : CollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
+  ArgsPostBase(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+               std::string_view curr_rule_file_path)
+      : CollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
+
+protected:
+  virtual void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                             std::string_view value) const = 0;
+
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
     auto& body_query_params = getBodyQueryParams(t);
@@ -41,13 +49,102 @@ protected:
   }
 
   void evaluateSpecifyCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& body_query_params_map = getBodyQueryParamsMap(t);
+    int64_t count = 0;
+    switch (subNameType()) {
+      [[likely]] case SubNameType::Literal : {
+        auto& body_query_params_map = getBodyQueryParamsMap(t);
+        count = body_query_params_map.count(sub_name_);
+      }
+      break;
+    case SubNameType::Regex:
+    case SubNameType::RegexFile: {
+      auto& body_query_params = getBodyQueryParams(t);
+      auto main_name = mainName();
 
-    int64_t count = body_query_params_map.count(sub_name_);
+      for (auto& elem : body_query_params) {
+        if (!hasExceptVariable(t, main_name, elem.first))
+          [[likely]] {
+            if (match(elem.first)) {
+              ++count;
+            }
+          }
+      }
+    } break;
+    case SubNameType::Macro: {
+      auto& body_query_params_map = getBodyQueryParamsMap(t);
+      Common::EvaluateResults macro_result;
+      evaluateMacro(t, macro_result);
+      for (auto& r : macro_result) {
+        assert(IS_STRING_VIEW_VARIANT(r.variant_));
+        if (IS_STRING_VIEW_VARIANT(r.variant_)) {
+          count += body_query_params_map.count(std::get<std::string_view>(r.variant_));
+        }
+      }
+    } break;
+    default:
+      UNREACHABLE();
+      break;
+    }
+
     result.emplace_back(count);
   }
 
-protected:
+  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
+    auto& body_query_params = getBodyQueryParams(t);
+    auto main_name = mainName();
+
+    for (auto& elem : body_query_params) {
+      if (!hasExceptVariable(t, main_name, elem.first))
+        [[likely]] { addResultItem(result, elem.first, elem.second); }
+    }
+  }
+
+  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
+    switch (subNameType()) {
+      [[likely]] case SubNameType::Literal : {
+        auto& body_query_params_map = getBodyQueryParamsMap(t);
+
+        auto range = body_query_params_map.equal_range(sub_name_);
+        for (auto iter = range.first; iter != range.second; ++iter) {
+          addResultItem(result, iter->first, iter->second);
+        }
+      }
+      break;
+    case SubNameType::Regex:
+    case SubNameType::RegexFile: {
+      auto& body_query_params = getBodyQueryParams(t);
+      auto main_name = mainName();
+
+      for (auto& elem : body_query_params) {
+        if (!hasExceptVariable(t, main_name, elem.first))
+          [[likely]] {
+            if (match(elem.first)) {
+              addResultItem(result, elem.first, elem.second);
+            }
+          }
+      }
+    } break;
+    case SubNameType::Macro: {
+      auto& body_query_params_map = getBodyQueryParamsMap(t);
+      Common::EvaluateResults macro_result;
+      evaluateMacro(t, macro_result);
+      for (auto& r : macro_result) {
+        assert(IS_STRING_VIEW_VARIANT(r.variant_));
+        if (IS_STRING_VIEW_VARIANT(r.variant_)) {
+          auto range = body_query_params_map.equal_range(std::get<std::string_view>(r.variant_));
+          for (auto iter = range.first; iter != range.second; ++iter) {
+            addResultItem(result, iter->first, iter->second);
+          }
+        }
+      }
+    } break;
+    default:
+      UNREACHABLE();
+      break;
+    }
+  }
+
+private:
   const std::vector<std::pair<std::string_view, std::string_view>>&
   getBodyQueryParams(Transaction& t) const {
     switch (t.getRequestBodyProcessor()) {
@@ -82,38 +179,14 @@ public:
            std::string_view curr_rule_file_path)
       : ArgsPostBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
+  ArgsPost(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : ArgsPostBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
+
 protected:
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& body_query_params = getBodyQueryParams(t);
-
-    for (auto& elem : body_query_params) {
-      if (!hasExceptVariable(t, main_name_, elem.first))
-        [[likely]] { result.emplace_back(elem.second, elem.first); }
-    }
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& body_query_params_map = getBodyQueryParamsMap(t);
-
-        auto range = body_query_params_map.equal_range(sub_name_);
-        for (auto iter = range.first; iter != range.second; ++iter) {
-          result.emplace_back(iter->second);
-        }
-      }
-    else {
-      auto& body_query_params = getBodyQueryParams(t);
-
-      for (auto& elem : body_query_params) {
-        if (!hasExceptVariable(t, main_name_, elem.first))
-          [[likely]] {
-            if (match(elem.first)) {
-              result.emplace_back(elem.second, elem.first);
-            }
-          }
-      }
-    }
+  void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                     std::string_view value) const override {
+    result.emplace_back(value, key);
   }
 };
 } // namespace Variable

--- a/src/variable/args_post_names.h
+++ b/src/variable/args_post_names.h
@@ -32,38 +32,14 @@ public:
                 std::string_view curr_rule_file_path)
       : ArgsPostBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
+  ArgsPostNames(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                bool is_counter, std::string_view curr_rule_file_path)
+      : ArgsPostBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
+
 protected:
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& body_query_params = getBodyQueryParams(t);
-
-    for (auto& elem : body_query_params) {
-      if (!hasExceptVariable(t, main_name_, elem.first))
-        [[likely]] { result.emplace_back(elem.first, elem.first); }
-    }
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& body_query_params_map = getBodyQueryParamsMap(t);
-
-        auto range = body_query_params_map.equal_range(sub_name_);
-        for (auto iter = range.first; iter != range.second; ++iter) {
-          result.emplace_back(iter->first);
-        }
-      }
-    else {
-      auto& body_query_params = getBodyQueryParams(t);
-
-      for (auto& elem : body_query_params) {
-        if (!hasExceptVariable(t, main_name_, elem.first))
-          [[likely]] {
-            if (match(elem.first)) {
-              result.emplace_back(elem.first, elem.first);
-            }
-          }
-      }
-    }
+  void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                     std::string_view value) const override {
+    result.emplace_back(key, key);
   }
 };
 } // namespace Variable

--- a/src/variable/auth_type.h
+++ b/src/variable/auth_type.h
@@ -31,6 +31,13 @@ public:
   AuthType(std::string&& sub_name, bool is_not, bool is_counter,
            std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  AuthType(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/duration.h
+++ b/src/variable/duration.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class Duration final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   Duration(std::string&& sub_name, bool is_not, bool is_counter,
            std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  Duration(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/env.h
+++ b/src/variable/env.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "collection_base.h"
-#include "variable_base.h"
 
 namespace Wge {
 namespace Variable {
@@ -31,6 +30,10 @@ class Env final : public CollectionBase {
 public:
   Env(std::string&& sub_name, bool is_not, bool is_counter, std::string_view curr_rule_file_path)
       : CollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  Env(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+      std::string_view curr_rule_file_path)
+      : CollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/files_combined_size.h
+++ b/src/variable/files_combined_size.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class FilesCombinedSize final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   FilesCombinedSize(std::string&& sub_name, bool is_not, bool is_counter,
                     std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  FilesCombinedSize(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                    bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/files_names.h
+++ b/src/variable/files_names.h
@@ -32,38 +32,14 @@ public:
              std::string_view curr_rule_file_path)
       : FilesBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
+  FilesNames(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : FilesBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
+
 protected:
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& filename = t.getBodyMultiPart().getNameFileNameLinked();
-
-    for (auto& elem : filename) {
-      if (!hasExceptVariable(t, main_name_, elem.first))
-        [[likely]] { result.emplace_back(elem.first, elem.first); }
-    }
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& filename_map = t.getBodyMultiPart().getNameFileName();
-
-        auto iter = filename_map.find(sub_name_);
-        if (iter != filename_map.end()) {
-          result.emplace_back(iter->first);
-        }
-      }
-    else {
-      auto& filename = t.getBodyMultiPart().getNameFileNameLinked();
-
-      for (auto& elem : filename) {
-        if (!hasExceptVariable(t, main_name_, elem.first))
-          [[likely]] {
-            if (match(elem.first)) {
-              result.emplace_back(elem.first, elem.first);
-            }
-          }
-      }
-    }
+  void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                     std::string_view value) const override {
+    result.emplace_back(key, key);
   }
 };
 } // namespace Variable

--- a/src/variable/files_sizes.h
+++ b/src/variable/files_sizes.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class FilesSizes final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   FilesSizes(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  FilesSizes(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/files_tmp_content.h
+++ b/src/variable/files_tmp_content.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "collection_base.h"
-#include "variable_base.h"
 
 namespace Wge {
 namespace Variable {
@@ -32,6 +31,10 @@ public:
   FilesTmpContent(std::string&& sub_name, bool is_not, bool is_counter,
                   std::string_view curr_rule_file_path)
       : CollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  FilesTmpContent(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : CollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/files_tmpnames.h
+++ b/src/variable/files_tmpnames.h
@@ -32,6 +32,10 @@ public:
   FilesTmpNames(std::string&& sub_name, bool is_not, bool is_counter,
                 std::string_view curr_rule_file_path)
       : CollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  FilesTmpNames(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                bool is_counter, std::string_view curr_rule_file_path)
+      : CollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/full_request.h
+++ b/src/variable/full_request.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class FullRequest final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   FullRequest(std::string&& sub_name, bool is_not, bool is_counter,
               std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  FullRequest(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+              std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/full_request_length.h
+++ b/src/variable/full_request_length.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class FullRequestLength final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   FullRequestLength(std::string&& sub_name, bool is_not, bool is_counter,
                     std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  FullRequestLength(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                    bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/geo.h
+++ b/src/variable/geo.h
@@ -30,6 +30,10 @@ class Geo final : public CollectionBase {
 public:
   Geo(std::string&& sub_name, bool is_not, bool is_counter, std::string_view curr_rule_file_path)
       : CollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  Geo(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+      std::string_view curr_rule_file_path)
+      : CollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/global.h
+++ b/src/variable/global.h
@@ -32,43 +32,10 @@ public:
       : PersistentCollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path,
                                  PersistentStorage::Storage::Type::GLOBAL) {}
 
-protected:
-  void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    result.emplace_back(static_cast<int64_t>(size(t)));
-  }
-
-  void evaluateSpecifyCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& value = get(t, sub_name_);
-    result.emplace_back(IS_EMPTY_VARIANT(value) ? 0 : 1);
-  }
-
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    travel(t, [&](const std::string& key, const Common::Variant& value) {
-      if (!hasExceptVariable(t, main_name_, key))
-        [[likely]] { result.emplace_back(value, key); }
-      return true;
-    });
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& value = get(t, sub_name_);
-        if (!IS_EMPTY_VARIANT(value))
-          [[likely]] { result.emplace_back(value); }
-      }
-    else {
-      travel(t, [&](const std::string& key, const Common::Variant& value) {
-        if (!hasExceptVariable(t, main_name_, key))
-          [[likely]] {
-            if (match(key)) {
-              result.emplace_back(value, key);
-            }
-          }
-        return true;
-      });
-    }
-  }
+  Global(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+         std::string_view curr_rule_file_path)
+      : PersistentCollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path,
+                                 PersistentStorage::Storage::Type::GLOBAL) {}
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/highest_severity.h
+++ b/src/variable/highest_severity.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class HighestSeverity final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   HighestSeverity(std::string&& sub_name, bool is_not, bool is_counter,
                   std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  HighestSeverity(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/inbound_data_error.h
+++ b/src/variable/inbound_data_error.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class InboundDataError final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   InboundDataError(std::string&& sub_name, bool is_not, bool is_counter,
                    std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  InboundDataError(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                   bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/ip.h
+++ b/src/variable/ip.h
@@ -32,43 +32,10 @@ public:
       : PersistentCollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path,
                                  PersistentStorage::Storage::Type::IP) {}
 
-protected:
-  void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    result.emplace_back(static_cast<int64_t>(size(t)));
-  }
-
-  void evaluateSpecifyCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& value = get(t, sub_name_);
-    result.emplace_back(IS_EMPTY_VARIANT(value) ? 0 : 1);
-  }
-
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    travel(t, [&](const std::string& key, const Common::Variant& value) {
-      if (!hasExceptVariable(t, main_name_, key))
-        [[likely]] { result.emplace_back(value, key); }
-      return true;
-    });
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& value = get(t, sub_name_);
-        if (!IS_EMPTY_VARIANT(value))
-          [[likely]] { result.emplace_back(value); }
-      }
-    else {
-      travel(t, [&](const std::string& key, const Common::Variant& value) {
-        if (!hasExceptVariable(t, main_name_, key))
-          [[likely]] {
-            if (match(key)) {
-              result.emplace_back(value, key);
-            }
-          }
-        return true;
-      });
-    }
-  }
+  Ip(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+     std::string_view curr_rule_file_path)
+      : PersistentCollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path,
+                                 PersistentStorage::Storage::Type::IP) {}
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/matched_optree.h
+++ b/src/variable/matched_optree.h
@@ -22,6 +22,8 @@
 
 #include "matched_ptree_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MatchedOPTree final : public MatchedPTreeBase {
@@ -31,6 +33,13 @@ public:
   MatchedOPTree(std::string&& sub_name, bool is_not, bool is_counter,
                 std::string_view curr_rule_file_path)
       : MatchedPTreeBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  MatchedOPTree(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                bool is_counter, std::string_view curr_rule_file_path)
+      : MatchedPTreeBase("", is_not, is_counter, curr_rule_file_path) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/matched_var.h
+++ b/src/variable/matched_var.h
@@ -22,12 +22,21 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MatchedVarBase : public VariableBase {
 public:
   MatchedVarBase(std::string&& sub_name, bool is_not, bool is_counter)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MatchedVarBase(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                 bool is_counter)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
@@ -72,6 +81,13 @@ public:
   MatchedVar(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : MatchedVarBase(std::move(sub_name), is_not, is_counter) {}
+
+  MatchedVar(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : MatchedVarBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/matched_var_name.h
+++ b/src/variable/matched_var_name.h
@@ -22,6 +22,8 @@
 
 #include "matched_var.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MatchedVarName final : public MatchedVarBase {
@@ -31,6 +33,13 @@ public:
   MatchedVarName(std::string&& sub_name, bool is_not, bool is_counter,
                  std::string_view curr_rule_file_path)
       : MatchedVarBase(std::move(sub_name), is_not, is_counter) {}
+
+  MatchedVarName(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                 bool is_counter, std::string_view curr_rule_file_path)
+      : MatchedVarBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/matched_vars.h
+++ b/src/variable/matched_vars.h
@@ -22,6 +22,8 @@
 
 #include "collection_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MatchedVarsBase : public CollectionBase {
@@ -29,6 +31,13 @@ public:
   MatchedVarsBase(std::string&& sub_name, bool is_not, bool is_counter,
                   std::string_view curr_rule_file_path)
       : CollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  MatchedVarsBase(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : CollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
@@ -64,6 +73,10 @@ public:
   MatchedVars(std::string&& sub_name, bool is_not, bool is_counter,
               std::string_view curr_rule_file_path)
       : MatchedVarsBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  MatchedVars(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+              std::string_view curr_rule_file_path)
+      : MatchedVarsBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 
 protected:
   void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/matched_vars_names.h
+++ b/src/variable/matched_vars_names.h
@@ -22,6 +22,8 @@
 
 #include "matched_vars.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MatchedVarsNames final : public MatchedVarsBase {
@@ -31,6 +33,10 @@ public:
   MatchedVarsNames(std::string&& sub_name, bool is_not, bool is_counter,
                    std::string_view curr_rule_file_path)
       : MatchedVarsBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  MatchedVarsNames(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                   bool is_counter, std::string_view curr_rule_file_path)
+      : MatchedVarsBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 
 protected:
   void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/matched_vptree.h
+++ b/src/variable/matched_vptree.h
@@ -22,6 +22,8 @@
 
 #include "matched_ptree_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MatchedVPTree final : public MatchedPTreeBase {
@@ -31,6 +33,13 @@ public:
   MatchedVPTree(std::string&& sub_name, bool is_not, bool is_counter,
                 std::string_view curr_rule_file_path)
       : MatchedPTreeBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  MatchedVPTree(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                bool is_counter, std::string_view curr_rule_file_path)
+      : MatchedPTreeBase("", is_not, is_counter, curr_rule_file_path) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/modsec_build.h
+++ b/src/variable/modsec_build.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ModSecBuild final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ModSecBuild(std::string&& sub_name, bool is_not, bool is_counter,
               std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ModSecBuild(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+              std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/msc_pcre_limits_exceeded.h
+++ b/src/variable/msc_pcre_limits_exceeded.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MscPcreLimitsExceeded final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MscPcreLimitsExceeded(std::string&& sub_name, bool is_not, bool is_counter,
                         std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MscPcreLimitsExceeded(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                        bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_boundary_quoted.h
+++ b/src/variable/multipart_boundary_quoted.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartBoundaryQuoted final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartBoundaryQuoted(std::string&& sub_name, bool is_not, bool is_counter,
                           std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartBoundaryQuoted(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                          bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_boundary_whitespace.h
+++ b/src/variable/multipart_boundary_whitespace.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartBoundaryWhitespace final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartBoundaryWhitespace(std::string&& sub_name, bool is_not, bool is_counter,
                               std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartBoundaryWhitespace(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                              bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_crlf_lf_lines.h
+++ b/src/variable/multipart_crlf_lf_lines.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartCrlfLfLines final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartCrlfLfLines(std::string&& sub_name, bool is_not, bool is_counter,
                        std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartCrlfLfLines(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                       bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_data_after.h
+++ b/src/variable/multipart_data_after.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartDataAfter final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartDataAfter(std::string&& sub_name, bool is_not, bool is_counter,
                      std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartDataAfter(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                     bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_data_before.h
+++ b/src/variable/multipart_data_before.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartDataBefore final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartDataBefore(std::string&& sub_name, bool is_not, bool is_counter,
                       std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartDataBefore(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                      bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_file_limit_exceeded.h
+++ b/src/variable/multipart_file_limit_exceeded.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartFileLimitExceeded final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartFileLimitExceeded(std::string&& sub_name, bool is_not, bool is_counter,
                              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartFileLimitExceeded(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                             bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_filename.h
+++ b/src/variable/multipart_filename.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartFileName final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartFileName(std::string&& sub_name, bool is_not, bool is_counter,
                     std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartFileName(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                    bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_header_folding.h
+++ b/src/variable/multipart_header_folding.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartHeaderFolding final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartHeaderFolding(std::string&& sub_name, bool is_not, bool is_counter,
                          std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartHeaderFolding(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                         bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_invalid_header_folding.h
+++ b/src/variable/multipart_invalid_header_folding.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartInvalidHeaderFolding final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartInvalidHeaderFolding(std::string&& sub_name, bool is_not, bool is_counter,
                                 std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartInvalidHeaderFolding(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                                bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_invalid_part.h
+++ b/src/variable/multipart_invalid_part.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartInvalidPart final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartInvalidPart(std::string&& sub_name, bool is_not, bool is_counter,
                        std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartInvalidPart(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                       bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_invalid_quoting.h
+++ b/src/variable/multipart_invalid_quoting.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartInvalidQuoting final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartInvalidQuoting(std::string&& sub_name, bool is_not, bool is_counter,
                           std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartInvalidQuoting(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                          bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_lf_line.h
+++ b/src/variable/multipart_lf_line.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartLfLine final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartLfLine(std::string&& sub_name, bool is_not, bool is_counter,
                   std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartLfLine(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_missing_semicolon.h
+++ b/src/variable/multipart_missing_semicolon.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartMissingSemicolon final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartMissingSemicolon(std::string&& sub_name, bool is_not, bool is_counter,
                             std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartMissingSemicolon(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                            bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_name.h
+++ b/src/variable/multipart_name.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartName final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartName(std::string&& sub_name, bool is_not, bool is_counter,
                 std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartName(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/multipart_strict_error.h
+++ b/src/variable/multipart_strict_error.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartStrictError final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartStrictError(std::string&& sub_name, bool is_not, bool is_counter,
                        std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartStrictError(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                       bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/multipart_unmatched_boundary.h
+++ b/src/variable/multipart_unmatched_boundary.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class MultipartUnmatchedBoundary final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   MultipartUnmatchedBoundary(std::string&& sub_name, bool is_not, bool is_counter,
                              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  MultipartUnmatchedBoundary(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                             bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/outbound_data_error.h
+++ b/src/variable/outbound_data_error.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class OutboundDataError final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   OutboundDataError(std::string&& sub_name, bool is_not, bool is_counter,
                     std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  OutboundDataError(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                    bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/path_info.h
+++ b/src/variable/path_info.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class PathInfo final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   PathInfo(std::string&& sub_name, bool is_not, bool is_counter,
            std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  PathInfo(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/ptree.h
+++ b/src/variable/ptree.h
@@ -23,6 +23,7 @@
 #include "variable_base.h"
 
 #include "../common/property_tree.h"
+#include "../macro/variable_macro.h"
 
 namespace Wge {
 namespace Variable {
@@ -54,6 +55,13 @@ public:
         }
       }
     }
+  }
+
+  PTree(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+        std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
   }
 
 protected:

--- a/src/variable/query_string.h
+++ b/src/variable/query_string.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class QueryString final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   QueryString(std::string&& sub_name, bool is_not, bool is_counter,
               std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  QueryString(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+              std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/remote_addr.h
+++ b/src/variable/remote_addr.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RemoteAddr final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RemoteAddr(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RemoteAddr(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/remote_host.h
+++ b/src/variable/remote_host.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RemoteHost final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RemoteHost(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RemoteHost(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/remote_port.h
+++ b/src/variable/remote_port.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RemotePort final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RemotePort(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RemotePort(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/remote_user.h
+++ b/src/variable/remote_user.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RemoteUser final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RemoteUser(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RemoteUser(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/reqbody_error.h
+++ b/src/variable/reqbody_error.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ReqBodyError final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ReqBodyError(std::string&& sub_name, bool is_not, bool is_counter,
                std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ReqBodyError(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+               std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/reqbody_error_msg.h
+++ b/src/variable/reqbody_error_msg.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ReqBodyErrorMsg final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ReqBodyErrorMsg(std::string&& sub_name, bool is_not, bool is_counter,
                   std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ReqBodyErrorMsg(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/reqbody_processor.h
+++ b/src/variable/reqbody_processor.h
@@ -25,6 +25,7 @@
 #include "variable_base.h"
 
 #include "../config.h"
+#include "../macro/variable_macro.h"
 
 namespace Wge {
 namespace Variable {
@@ -35,6 +36,13 @@ public:
   ReqBodyProcessor(std::string&& sub_name, bool is_not, bool is_counter,
                    std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ReqBodyProcessor(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                   bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/reqbody_processor_error.h
+++ b/src/variable/reqbody_processor_error.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ReqbodyProcessorError final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ReqbodyProcessorError(std::string&& sub_name, bool is_not, bool is_counter,
                         std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ReqbodyProcessorError(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                        bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/request_basename.h
+++ b/src/variable/request_basename.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RequestBaseName final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RequestBaseName(std::string&& sub_name, bool is_not, bool is_counter,
                   std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RequestBaseName(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/request_body.h
+++ b/src/variable/request_body.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RequestBody final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RequestBody(std::string&& sub_name, bool is_not, bool is_counter,
               std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RequestBody(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+              std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/request_body_length.h
+++ b/src/variable/request_body_length.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RequestBodyLength final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RequestBodyLength(std::string&& sub_name, bool is_not, bool is_counter,
                     std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RequestBodyLength(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                    bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/request_cookies_names.h
+++ b/src/variable/request_cookies_names.h
@@ -32,36 +32,14 @@ public:
                       std::string_view curr_rule_file_path)
       : RequestCookiesBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
+  RequestCookiesNames(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                      bool is_counter, std::string_view curr_rule_file_path)
+      : RequestCookiesBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
+
 protected:
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    const std::unordered_multimap<std::string_view, std::string_view>& cookies = t.getCookies();
-
-    for (auto& elem : cookies) {
-      if (!hasExceptVariable(t, main_name_, elem.first))
-        [[likely]] { result.emplace_back(elem.first, elem.first); }
-    }
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    const std::unordered_multimap<std::string_view, std::string_view>& cookies = t.getCookies();
-
-    if (!isRegex())
-      [[likely]] {
-        auto range = cookies.equal_range(sub_name_);
-        for (auto it = range.first; it != range.second; ++it) {
-          result.emplace_back(it->first);
-        }
-      }
-    else {
-      for (auto& elem : cookies) {
-        if (!hasExceptVariable(t, main_name_, elem.first))
-          [[likely]] {
-            if (match(elem.first)) {
-              result.emplace_back(elem.first, elem.first);
-            }
-          }
-      }
-    }
+  void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                     std::string_view value) const override {
+    result.emplace_back(key, key);
   }
 };
 } // namespace Variable

--- a/src/variable/request_filename.h
+++ b/src/variable/request_filename.h
@@ -32,6 +32,13 @@ public:
                   std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
 
+  RequestFileName(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
+
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
     result.emplace_back(t.getRequestLineInfo().relative_uri_.empty() ? 0 : 1);

--- a/src/variable/request_headers_names.h
+++ b/src/variable/request_headers_names.h
@@ -32,35 +32,14 @@ public:
                       std::string_view curr_rule_file_path)
       : RequestHeadersBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
-protected:
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    t.httpExtractor().request_header_traversal_([&](std::string_view key, std::string_view value) {
-      if (!hasExceptVariable(t, main_name_, key))
-        [[likely]] { result.emplace_back(key, key); }
-      return true;
-    });
-  }
+  RequestHeadersNames(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                      bool is_counter, std::string_view curr_rule_file_path)
+      : RequestHeadersBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        std::vector<std::string_view> values = t.httpExtractor().request_header_find_(sub_name_);
-        for (size_t i = 0; i < values.size(); ++i) {
-          result.emplace_back(sub_name_);
-        }
-      }
-    else {
-      t.httpExtractor().request_header_traversal_(
-          [&](std::string_view key, std::string_view value) {
-            if (!hasExceptVariable(t, main_name_, key))
-              [[likely]] {
-                if (match(key)) {
-                  result.emplace_back(key, key);
-                }
-              }
-            return true;
-          });
-    }
+protected:
+  void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                     std::string_view value) const override {
+    result.emplace_back(key, key);
   }
 };
 } // namespace Variable

--- a/src/variable/request_line.h
+++ b/src/variable/request_line.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RequestLine final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RequestLine(std::string&& sub_name, bool is_not, bool is_counter,
               std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RequestLine(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+              std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/request_method.h
+++ b/src/variable/request_method.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RequestMothod final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RequestMothod(std::string&& sub_name, bool is_not, bool is_counter,
                 std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RequestMothod(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/request_protocol.h
+++ b/src/variable/request_protocol.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RequestProtocol final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RequestProtocol(std::string&& sub_name, bool is_not, bool is_counter,
                   std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RequestProtocol(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/request_uri.h
+++ b/src/variable/request_uri.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RequestUri final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RequestUri(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RequestUri(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/request_uri_raw.h
+++ b/src/variable/request_uri_raw.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class RequestUriRaw final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   RequestUriRaw(std::string&& sub_name, bool is_not, bool is_counter,
                 std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  RequestUriRaw(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/resource.h
+++ b/src/variable/resource.h
@@ -33,43 +33,10 @@ public:
       : PersistentCollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path,
                                  PersistentStorage::Storage::Type::RESOURCE) {}
 
-protected:
-  void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    result.emplace_back(static_cast<int64_t>(size(t)));
-  }
-
-  void evaluateSpecifyCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& value = get(t, sub_name_);
-    result.emplace_back(IS_EMPTY_VARIANT(value) ? 0 : 1);
-  }
-
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    travel(t, [&](const std::string& key, const Common::Variant& value) {
-      if (!hasExceptVariable(t, main_name_, key))
-        [[likely]] { result.emplace_back(value, key); }
-      return true;
-    });
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& value = get(t, sub_name_);
-        if (!IS_EMPTY_VARIANT(value))
-          [[likely]] { result.emplace_back(value); }
-      }
-    else {
-      travel(t, [&](const std::string& key, const Common::Variant& value) {
-        if (!hasExceptVariable(t, main_name_, key))
-          [[likely]] {
-            if (match(key)) {
-              result.emplace_back(value, key);
-            }
-          }
-        return true;
-      });
-    }
-  }
+  Resource(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : PersistentCollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path,
+                                 PersistentStorage::Storage::Type::RESOURCE) {}
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/response_body.h
+++ b/src/variable/response_body.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ResponseBody final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ResponseBody(std::string&& sub_name, bool is_not, bool is_counter,
                std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ResponseBody(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+               std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/response_content_length.h
+++ b/src/variable/response_content_length.h
@@ -23,6 +23,8 @@
 #include "response_headers.h"
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ResponseContentLength final : public VariableBase {
@@ -33,6 +35,14 @@ public:
                         std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter),
         response_content_length_("content-length", is_not, is_counter, curr_rule_file_path) {}
+
+  ResponseContentLength(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                        bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter),
+        response_content_length_("content-length", is_not, is_counter, curr_rule_file_path) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/response_content_type.h
+++ b/src/variable/response_content_type.h
@@ -23,6 +23,8 @@
 #include "response_headers.h"
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ResponseContentType final : public VariableBase {
@@ -33,6 +35,14 @@ public:
                       std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter),
         response_content_type_("content-type", is_not, is_counter, curr_rule_file_path) {}
+
+  ResponseContentType(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                      bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter),
+        response_content_type_("content-type", is_not, is_counter, curr_rule_file_path) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/response_headers.h
+++ b/src/variable/response_headers.h
@@ -30,14 +30,114 @@ public:
                       std::string_view curr_rule_file_path)
       : CollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
+  ResponseHeadersBase(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                      bool is_counter, std::string_view curr_rule_file_path)
+      : CollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
+
+protected:
+  virtual void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                             std::string_view value) const = 0;
+
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
     result.emplace_back(static_cast<int64_t>(t.httpExtractor().response_header_count_));
   }
 
   void evaluateSpecifyCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    result.emplace_back(
-        static_cast<int64_t>(t.httpExtractor().response_header_find_(sub_name_).size()));
+    int64_t count = 0;
+    switch (subNameType()) {
+      [[likely]] case SubNameType::Literal : {
+        count += t.httpExtractor().response_header_find_(sub_name_).size();
+      }
+      break;
+    case SubNameType::Regex:
+    case SubNameType::RegexFile: {
+      auto main_name = mainName();
+      t.httpExtractor().response_header_traversal_(
+          [&](std::string_view key, std::string_view value) {
+            if (!hasExceptVariable(t, main_name, key))
+              [[likely]] {
+                if (match(key)) {
+                  ++count;
+                }
+              }
+            return true;
+          });
+    } break;
+    case SubNameType::Macro: {
+      Common::EvaluateResults macro_result;
+      evaluateMacro(t, macro_result);
+      for (auto& r : macro_result) {
+        assert(IS_STRING_VIEW_VARIANT(r.variant_));
+        if (IS_STRING_VIEW_VARIANT(r.variant_)) {
+          std::string_view sub_name = std::get<std::string_view>(r.variant_);
+          std::vector<std::string_view> values = t.httpExtractor().response_header_find_(
+              std::string(sub_name.data(), sub_name.size()));
+          for (auto& value : values) {
+            ++count;
+          }
+        }
+      }
+    } break;
+    default:
+      UNREACHABLE();
+      break;
+    }
+
+    result.emplace_back(count);
+  }
+
+  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
+    auto main_name = mainName();
+    t.httpExtractor().response_header_traversal_([&](std::string_view key, std::string_view value) {
+      if (!hasExceptVariable(t, main_name, key))
+        [[likely]] { addResultItem(result, key, value); }
+      return true;
+    });
+  }
+
+  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
+    switch (subNameType()) {
+      [[likely]] case SubNameType::Literal : {
+        std::vector<std::string_view> values = t.httpExtractor().response_header_find_(sub_name_);
+        for (auto& value : values) {
+          addResultItem(result, sub_name_, value);
+        }
+      }
+      break;
+    case SubNameType::Regex:
+    case SubNameType::RegexFile: {
+      auto main_name = mainName();
+      t.httpExtractor().response_header_traversal_(
+          [&](std::string_view key, std::string_view value) {
+            if (!hasExceptVariable(t, main_name, key))
+              [[likely]] {
+                if (match(key)) {
+                  addResultItem(result, key, value);
+                }
+              }
+            return true;
+          });
+    } break;
+    case SubNameType::Macro: {
+      Common::EvaluateResults macro_result;
+      evaluateMacro(t, macro_result);
+      for (auto& r : macro_result) {
+        assert(IS_STRING_VIEW_VARIANT(r.variant_));
+        if (IS_STRING_VIEW_VARIANT(r.variant_)) {
+          std::string_view sub_name = std::get<std::string_view>(r.variant_);
+          std::vector<std::string_view> values = t.httpExtractor().response_header_find_(
+              std::string(sub_name.data(), sub_name.size()));
+          for (auto& value : values) {
+            addResultItem(result, sub_name_, value);
+          }
+        }
+      }
+    } break;
+    default:
+      UNREACHABLE();
+      break;
+    }
   }
 };
 
@@ -49,35 +149,14 @@ public:
                   std::string_view curr_rule_file_path)
       : ResponseHeadersBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
-protected:
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    t.httpExtractor().response_header_traversal_([&](std::string_view key, std::string_view value) {
-      if (!hasExceptVariable(t, main_name_, key))
-        [[likely]] { result.emplace_back(value, key); }
-      return true;
-    });
-  }
+  ResponseHeaders(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : ResponseHeadersBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        std::vector<std::string_view> values = t.httpExtractor().response_header_find_(sub_name_);
-        for (auto& value : values) {
-          result.emplace_back(value, sub_name_);
-        }
-      }
-    else {
-      t.httpExtractor().response_header_traversal_(
-          [&](std::string_view key, std::string_view value) {
-            if (!hasExceptVariable(t, main_name_, key))
-              [[likely]] {
-                if (match(key)) {
-                  result.emplace_back(value, key);
-                }
-              }
-            return true;
-          });
-    }
+protected:
+  void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                     std::string_view value) const override {
+    result.emplace_back(value, key);
   }
 };
 } // namespace Variable

--- a/src/variable/response_headers_names.h
+++ b/src/variable/response_headers_names.h
@@ -32,35 +32,14 @@ public:
                        std::string_view curr_rule_file_path)
       : ResponseHeadersBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
 
-protected:
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    t.httpExtractor().response_header_traversal_([&](std::string_view key, std::string_view value) {
-      if (!hasExceptVariable(t, main_name_, key))
-        [[likely]] { result.emplace_back(key, key); }
-      return true;
-    });
-  }
+  ResponseHeadersNames(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                       bool is_counter, std::string_view curr_rule_file_path)
+      : ResponseHeadersBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {}
 
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        std::vector<std::string_view> values = t.httpExtractor().response_header_find_(sub_name_);
-        for (size_t i = 0; i < values.size(); ++i) {
-          result.emplace_back(sub_name_);
-        }
-      }
-    else {
-      t.httpExtractor().response_header_traversal_(
-          [&](std::string_view key, std::string_view value) {
-            if (!hasExceptVariable(t, main_name_, key))
-              [[likely]] {
-                if (match(key)) {
-                  result.emplace_back(key, key);
-                }
-              }
-            return true;
-          });
-    }
+protected:
+  void addResultItem(Common::EvaluateResults& result, std::string_view key,
+                     std::string_view value) const override {
+    result.emplace_back(key, key);
   }
 };
 } // namespace Variable

--- a/src/variable/response_protocol.h
+++ b/src/variable/response_protocol.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ResponseProtocol final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ResponseProtocol(std::string&& sub_name, bool is_not, bool is_counter,
                    std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ResponseProtocol(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                   bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/response_status.h
+++ b/src/variable/response_status.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ResponseStatus final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ResponseStatus(std::string&& sub_name, bool is_not, bool is_counter,
                  std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ResponseStatus(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                 bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/rule.h
+++ b/src/variable/rule.h
@@ -24,6 +24,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class Rule final : public VariableBase {
@@ -33,6 +35,13 @@ public:
   Rule(std::string&& sub_name, bool is_not, bool is_counter, std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {
     initEvaluateFunc();
+  }
+
+  Rule(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+       std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
   }
 
 protected:

--- a/src/variable/server_addr.h
+++ b/src/variable/server_addr.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ServerAddr final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ServerAddr(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ServerAddr(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/server_name.h
+++ b/src/variable/server_name.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ServerName final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ServerName(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ServerName(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/server_port.h
+++ b/src/variable/server_port.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class ServerPort final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   ServerPort(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  ServerPort(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/session.h
+++ b/src/variable/session.h
@@ -33,43 +33,10 @@ public:
       : PersistentCollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path,
                                  PersistentStorage::Storage::Type::SESSION) {}
 
-protected:
-  void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    result.emplace_back(static_cast<int64_t>(size(t)));
-  }
-
-  void evaluateSpecifyCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& value = get(t, sub_name_);
-    result.emplace_back(IS_EMPTY_VARIANT(value) ? 0 : 1);
-  }
-
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    travel(t, [&](const std::string& key, const Common::Variant& value) {
-      if (!hasExceptVariable(t, main_name_, key))
-        [[likely]] { result.emplace_back(value, key); }
-      return true;
-    });
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& value = get(t, sub_name_);
-        if (!IS_EMPTY_VARIANT(value))
-          [[likely]] { result.emplace_back(value); }
-      }
-    else {
-      travel(t, [&](const std::string& key, const Common::Variant& value) {
-        if (!hasExceptVariable(t, main_name_, key))
-          [[likely]] {
-            if (match(key)) {
-              result.emplace_back(value, key);
-            }
-          }
-        return true;
-      });
-    }
-  }
+  Session(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+          std::string_view curr_rule_file_path)
+      : PersistentCollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path,
+                                 PersistentStorage::Storage::Type::SESSION) {}
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/sessionid.h
+++ b/src/variable/sessionid.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class SessionId final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   SessionId(std::string&& sub_name, bool is_not, bool is_counter,
             std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  SessionId(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+            std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/status_line.h
+++ b/src/variable/status_line.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class StatusLine final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   StatusLine(std::string&& sub_name, bool is_not, bool is_counter,
              std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  StatusLine(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+             std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/time.h
+++ b/src/variable/time.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class Time final : public VariableBase {
@@ -30,6 +32,13 @@ class Time final : public VariableBase {
 public:
   Time(std::string&& sub_name, bool is_not, bool is_counter, std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  Time(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+       std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/time_day.h
+++ b/src/variable/time_day.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class TimeDay final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   TimeDay(std::string&& sub_name, bool is_not, bool is_counter,
           std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  TimeDay(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+          std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/time_epoch.h
+++ b/src/variable/time_epoch.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class TimeEpoch final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   TimeEpoch(std::string&& sub_name, bool is_not, bool is_counter,
             std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  TimeEpoch(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+            std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/time_hour.h
+++ b/src/variable/time_hour.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class TimeHour final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   TimeHour(std::string&& sub_name, bool is_not, bool is_counter,
            std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  TimeHour(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/time_min.h
+++ b/src/variable/time_min.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class TimeMin final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   TimeMin(std::string&& sub_name, bool is_not, bool is_counter,
           std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  TimeMin(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+          std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/time_mon.h
+++ b/src/variable/time_mon.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class TimeMon final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   TimeMon(std::string&& sub_name, bool is_not, bool is_counter,
           std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  TimeMon(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+          std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/time_sec.h
+++ b/src/variable/time_sec.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class TimeSec final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   TimeSec(std::string&& sub_name, bool is_not, bool is_counter,
           std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  TimeSec(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+          std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/time_wday.h
+++ b/src/variable/time_wday.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class TimeWDay final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   TimeWDay(std::string&& sub_name, bool is_not, bool is_counter,
            std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  TimeWDay(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/time_year.h
+++ b/src/variable/time_year.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class TimeYear final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   TimeYear(std::string&& sub_name, bool is_not, bool is_counter,
            std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  TimeYear(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/unique_id.h
+++ b/src/variable/unique_id.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 /**
@@ -36,6 +38,13 @@ public:
   UniqueId(std::string&& sub_name, bool is_not, bool is_counter,
            std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  UniqueId(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {

--- a/src/variable/urlencoded_error.h
+++ b/src/variable/urlencoded_error.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class UrlenCodedError final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   UrlenCodedError(std::string&& sub_name, bool is_not, bool is_counter,
                   std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  UrlenCodedError(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                  bool is_counter, std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/user.h
+++ b/src/variable/user.h
@@ -32,43 +32,10 @@ public:
       : PersistentCollectionBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path,
                                  PersistentStorage::Storage::Type::USER) {}
 
-protected:
-  void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    result.emplace_back(static_cast<int64_t>(size(t)));
-  }
-
-  void evaluateSpecifyCounter(Transaction& t, Common::EvaluateResults& result) const override {
-    auto& value = get(t, sub_name_);
-    result.emplace_back(IS_EMPTY_VARIANT(value) ? 0 : 1);
-  }
-
-  void evaluateCollection(Transaction& t, Common::EvaluateResults& result) const override {
-    travel(t, [&](const std::string& key, const Common::Variant& value) {
-      if (!hasExceptVariable(t, main_name_, key))
-        [[likely]] { result.emplace_back(value, key); }
-      return true;
-    });
-  }
-
-  void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
-    if (!isRegex())
-      [[likely]] {
-        auto& value = get(t, sub_name_);
-        if (!IS_EMPTY_VARIANT(value))
-          [[likely]] { result.emplace_back(value); }
-      }
-    else {
-      travel(t, [&](const std::string& key, const Common::Variant& value) {
-        if (!hasExceptVariable(t, main_name_, key))
-          [[likely]] {
-            if (match(key)) {
-              result.emplace_back(value, key);
-            }
-          }
-        return true;
-      });
-    }
-  }
+  User(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+       std::string_view curr_rule_file_path)
+      : PersistentCollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path,
+                                 PersistentStorage::Storage::Type::USER) {}
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/userid.h
+++ b/src/variable/userid.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class UserId final : public VariableBase {
@@ -30,6 +32,13 @@ class UserId final : public VariableBase {
 public:
   UserId(std::string&& sub_name, bool is_not, bool is_counter, std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  UserId(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+         std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/webappid.h
+++ b/src/variable/webappid.h
@@ -22,6 +22,8 @@
 
 #include "variable_base.h"
 
+#include "../macro/variable_macro.h"
+
 namespace Wge {
 namespace Variable {
 class WebAppId final : public VariableBase {
@@ -31,6 +33,13 @@ public:
   WebAppId(std::string&& sub_name, bool is_not, bool is_counter,
            std::string_view curr_rule_file_path)
       : VariableBase(std::move(sub_name), is_not, is_counter) {}
+
+  WebAppId(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+           std::string_view curr_rule_file_path)
+      : VariableBase("", is_not, is_counter) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
 };
 } // namespace Variable
 } // namespace Wge

--- a/src/variable/xml.h
+++ b/src/variable/xml.h
@@ -61,6 +61,13 @@ public:
             }(),
             is_not, is_counter, curr_rule_file_path) {}
 
+  Xml(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
+      std::string_view curr_rule_file_path)
+      : CollectionBase(std::move(sub_name_macro), is_not, is_counter, curr_rule_file_path) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
+
 protected:
   void evaluateCollectionCounter(Transaction& t, Common::EvaluateResults& result) const override {
     auto& kv_pairs = getKvPairs(t);
@@ -99,8 +106,8 @@ protected:
   void evaluateSpecify(Transaction& t, Common::EvaluateResults& result) const override {
     auto& kv_pairs = getKvPairs(t);
 
-    if (!isRegex())
-      [[likely]] {
+    switch (subNameType()) {
+      [[likely]] case SubNameType::Literal : {
         switch (type_) {
         case Type::AttrValue: {
           for (auto& elem : kv_pairs) {
@@ -121,7 +128,9 @@ protected:
           UNREACHABLE();
         }
       }
-    else {
+      break;
+    case SubNameType::Regex:
+    case SubNameType::RegexFile: {
       switch (type_) {
       case Type::AttrValue: {
         UNREACHABLE();
@@ -147,6 +156,13 @@ protected:
       default:
         UNREACHABLE();
       }
+    } break;
+    case SubNameType::Macro: {
+      UNREACHABLE();
+    } break;
+    default:
+      UNREACHABLE();
+      break;
     }
   }
 

--- a/test/parser/rule_variable_parse_test.cc
+++ b/test/parser/rule_variable_parse_test.cc
@@ -232,5 +232,43 @@ TEST_F(RuleVariableParseTest, MatchedVPTree) {
   EXPECT_EQ(variable3->paths().size(), 0);
 }
 
+TEST_F(RuleVariableParseTest, SubnameWithMacro) {
+  {
+    const std::string directive =
+        R"(SecRule ARGS:%{PTREE.foo.bar}|ARGS:%{PTREE.foo[].bar}|ARGS:%{PTREE.foo.bar{}} "@eq 100" "id:1,phase:1")";
+
+    Antlr4::Parser parser;
+    auto result = parser.load(directive);
+    ASSERT_TRUE(result.has_value());
+
+    auto& variables = parser.rules()[0].back().variables();
+    EXPECT_EQ(variables.size(), 3);
+    const auto* variable0 = dynamic_cast<const Variable::Args*>(variables[0].get());
+    const auto* variable1 = dynamic_cast<const Variable::Args*>(variables[1].get());
+    const auto* variable2 = dynamic_cast<const Variable::Args*>(variables[2].get());
+    EXPECT_EQ(variable0->subNameType(), Variable::CollectionBase::SubNameType::Macro);
+    EXPECT_EQ(variable1->subNameType(), Variable::CollectionBase::SubNameType::Macro);
+    EXPECT_EQ(variable2->subNameType(), Variable::CollectionBase::SubNameType::Macro);
+  }
+
+  {
+    const std::string directive =
+        R"(SecRule TX:%{PTREE.foo.bar}|TX:%{PTREE.foo[].bar}|TX:%{PTREE.foo.bar{}} "@eq 100" "id:1,phase:1")";
+
+    Antlr4::Parser parser;
+    auto result = parser.load(directive);
+    ASSERT_TRUE(result.has_value());
+
+    auto& variables = parser.rules()[0].back().variables();
+    EXPECT_EQ(variables.size(), 3);
+    const auto* variable0 = dynamic_cast<const Variable::Tx*>(variables[0].get());
+    const auto* variable1 = dynamic_cast<const Variable::Tx*>(variables[1].get());
+    const auto* variable2 = dynamic_cast<const Variable::Tx*>(variables[2].get());
+    EXPECT_EQ(variable0->subNameType(), Variable::CollectionBase::SubNameType::Macro);
+    EXPECT_EQ(variable1->subNameType(), Variable::CollectionBase::SubNameType::Macro);
+    EXPECT_EQ(variable2->subNameType(), Variable::CollectionBase::SubNameType::Macro);
+  }
+}
+
 } // namespace Parser
 } // namespace Wge


### PR DESCRIPTION
Support using macros as subnames for variables. This allows for more dynamic variable references based on runtime evaluations. Such as:
```
SecRule TX:%{tx.%{tx.%{tx.var_name}}} "@eq 1" "id:1,phase:2"
```