### PR TITLE
fix(rule): clear matched vars correctly

### DIFF
--- a/src/rule.cc
+++ b/src/rule.cc
@@ -494,7 +494,7 @@ bool Rule::evaluateChain(Transaction& t) const {
   // Restore the current rule to the transaction
   t.setCurrentEvaluateRule(this);
 
-  if (multiMatch())
+  if (matchedMultiChain() || unmatchedMultiChain())
     [[unlikely]] {
       t.clearMatchedVariables(chain_->chain_index_,
                               chain_->chain_index_ + detail_->chain_rule_count_);


### PR DESCRIPTION
Clear matched variables only when there are multiChain matches, not on multiMatch.
Related: #112