### PR TITLE
feat(antlr4): add SecFragmentRule directive

### DIFF
--- a/src/antlr4/SecLangParser.g4
+++ b/src/antlr4/SecLangParser.g4
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  * 
  * MIT License (http://opensource.org/licenses/MIT)
  * 
@@ -127,9 +127,14 @@ sec_rule_update_target_by_tag:
 sec_marker: SecMarker ((QUOTE STRING QUOTE) | STRING);
 
 sec_rule:
-	SecRule variables QUOTE operator (PIPE operator)* QUOTE (
-		QUOTE action (COMMA? action)* QUOTE
-	)?;
+	SecRule (
+		(
+			variables QUOTE operator (PIPE operator)* QUOTE (
+				QUOTE action (COMMA? action)* QUOTE
+			)?
+		)
+		| (FRAGMENT COLON STRING)
+	);
 
 variables: variable (PIPE variable)*;
 
@@ -1598,7 +1603,8 @@ sec_component_signature:
 extension_directive:
 	sec_rule_update_operator_by_id
 	| sec_rule_update_operator_by_tag
-	| sec_tx_namespace;
+	| sec_tx_namespace
+	| sec_fragment_rule;
 sec_rule_update_operator_by_id:
 	SecRuleUpdateOperatorById (
 		INT
@@ -1612,3 +1618,7 @@ sec_rule_update_operator_by_tag:
 		PIPE operator
 	)* QUOTE;
 sec_tx_namespace: SecTxNamespace STRING;
+sec_fragment_rule:
+	SecFragmentRule STRING variables QUOTE operator (
+		PIPE operator
+	)* QUOTE (QUOTE action (COMMA? action)* QUOTE)?;

--- a/src/antlr4/parser.cc
+++ b/src/antlr4/parser.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  *
  * MIT License (http://opensource.org/licenses/MIT)
  *
@@ -75,12 +75,14 @@ public:
   std::string error_msg;
 };
 
-Parser::Parser() {
+Parser::Parser() : visitor_(std::make_unique<Visitor>(this)) {
   constexpr size_t tx_variable_index_size = 1000;
   auto inserted_iter = tx_variable_index_.emplace("", TxVariableIndex{}).first;
   inserted_iter->second.index_.reserve(tx_variable_index_size);
   inserted_iter->second.index_reverse_.reserve(tx_variable_index_size);
 }
+
+Parser::~Parser() = default;
 
 std::expected<bool, std::string> Parser::loadFromFile(const std::string& file_path) {
   // Init
@@ -124,8 +126,7 @@ std::expected<bool, std::string> Parser::loadFromFile(const std::string& file_pa
 
   // Visit
   std::string error;
-  Visitor vistor(this);
-  TRY_NOCATCH(error = std::any_cast<std::string>(vistor.visit(tree)));
+  TRY_NOCATCH(error = std::any_cast<std::string>(visitor_->visit(tree)));
 
   curr_load_file_.pop();
 
@@ -163,8 +164,7 @@ std::expected<bool, std::string> Parser::load(const std::string& directive) {
 
   // visit
   std::string error;
-  Visitor vistor(this);
-  TRY_NOCATCH(error = std::any_cast<std::string>(vistor.visit(tree)));
+  TRY_NOCATCH(error = std::any_cast<std::string>(visitor_->visit(tree)));
 
   if (!error.empty()) {
     return std::unexpected(error);

--- a/src/antlr4/parser.h
+++ b/src/antlr4/parser.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  *
  * MIT License (http://opensource.org/licenses/MIT)
  *
@@ -37,12 +37,15 @@
 
 namespace Wge::Antlr4 {
 
+class Visitor;
+
 /**
  * SecLang parser
  */
 class Parser {
 public:
   Parser();
+  ~Parser();
 
 public:
   /**
@@ -172,5 +175,6 @@ private:
   std::unordered_map<std::string /*namespace*/, TxVariableIndex> tx_variable_index_;
   std::unordered_map<std::string /*namespace*/, size_t> tx_variable_index_size_;
   std::string curr_namespace_;
+  std::unique_ptr<Visitor> visitor_;
 };
 } // namespace Wge::Antlr4

--- a/src/variable/ref.h
+++ b/src/variable/ref.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  *
  * MIT License (http://opensource.org/licenses/MIT)
  *
@@ -27,13 +27,14 @@
 namespace Wge {
 namespace Variable {
 class Ref final : public MatchedPTreeBase {
-  DECLARE_VIRABLE_NAME(Ref);
+public:
+  enum class RefType { MatchedOPtree, MatchedVPTree };
 
 public:
-  Ref(std::string&& key, std::string&& sub_name, bool is_not, bool is_counter,
+  Ref(RefType ref_type, std::string&& key, std::string&& sub_name, bool is_not, bool is_counter,
       std::string_view curr_rule_file_path)
       : MatchedPTreeBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path),
-        key_(std::move(key)) {}
+        ref_type_(ref_type), key_(std::move(key)) {}
 
   Ref(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not, bool is_counter,
       std::string_view curr_rule_file_path)
@@ -70,10 +71,34 @@ public:
   }
 
 public:
+  FullName fullName() const override {
+    if (ref_type_ == RefType::MatchedOPtree) {
+      return {optree_main_name_, sub_name_};
+    } else {
+      return {vptree_main_name_, sub_name_};
+    }
+  }
+
+  std::string_view mainName() const override {
+    if (ref_type_ == RefType::MatchedOPtree) {
+      return optree_main_name_;
+    } else {
+      return vptree_main_name_;
+    }
+  }
+
+public:
   const std::string& key() const { return key_; }
 
 private:
+  RefType ref_type_;
   std::string key_;
-};
+
+  // The different main names for different ref types are necessary
+  // They avoid conflicts when both MATCHED_OPTREE_REF and MATCHED_VPTREE_REF that have the same sub
+  // name are used in the same rule
+  static constexpr std::string_view optree_main_name_{"MATCHED_OPTREE_REF"};
+  static constexpr std::string_view vptree_main_name_{"MATCHED_VPTREE_REF"};
+}; // namespace Variable
 } // namespace Variable
 } // namespace Wge

--- a/test/parser/rule_action_parse_test.cc
+++ b/test/parser/rule_action_parse_test.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  *
  * MIT License (http://opensource.org/licenses/MIT)
  *
@@ -1126,7 +1126,7 @@ TEST_F(RuleActionParseTest, ActionAlias) {
   // 4. Test the alias were cleared after parsing is done.
   const std::string rule_directive = R"(
         SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,alias:test0=MATCHED_OPTREE,alias:test1=MATCHED_VPTREE../../foo.bar,alias:test2=MATCHED_OPTREE../,msg:'aaa',chain"
-          SecRule test0|test1:world|test0:foo[].bar|test0:foo[].bar{}|test1:../|test1:../bar1|test1:../../../../../|test1:../../../../../foo "@rx %{test2.for.bar}" "id:2,phase:1,msg:'bbb'"
+          SecRule test0|test1:world|test0:foo[].bar|test0:foo[].bar{}|test1:../|test1:../bar1|test1:../../../../../|test1:../../../../../foo|test2:../ "@rx %{test2.for.bar}" "id:2,phase:1,msg:'bbb'"
         SecRule test0|test1:world "baz" "id:3,phase:1,msg:'bbb'")";
 
   auto result = parser.load(rule_directive);
@@ -1136,7 +1136,7 @@ TEST_F(RuleActionParseTest, ActionAlias) {
   EXPECT_EQ(parser.rules()[0].size(), 1);
 
   auto& rule_var_pool = parser.rules()[0].front().chainRule(0)->variables();
-  ASSERT_EQ(rule_var_pool.size(), 8);
+  ASSERT_EQ(rule_var_pool.size(), 9);
   Variable::MatchedOPTree* var0 = dynamic_cast<Variable::MatchedOPTree*>(rule_var_pool[0].get());
   Variable::MatchedVPTree* var1 = dynamic_cast<Variable::MatchedVPTree*>(rule_var_pool[1].get());
   Variable::MatchedOPTree* var2 = dynamic_cast<Variable::MatchedOPTree*>(rule_var_pool[2].get());
@@ -1145,6 +1145,7 @@ TEST_F(RuleActionParseTest, ActionAlias) {
   Variable::MatchedVPTree* var5 = dynamic_cast<Variable::MatchedVPTree*>(rule_var_pool[5].get());
   Variable::MatchedVPTree* var6 = dynamic_cast<Variable::MatchedVPTree*>(rule_var_pool[6].get());
   Variable::MatchedVPTree* var7 = dynamic_cast<Variable::MatchedVPTree*>(rule_var_pool[7].get());
+  Variable::MatchedOPTree* var8 = dynamic_cast<Variable::MatchedOPTree*>(rule_var_pool[8].get());
   ASSERT_NE(var0, nullptr);
   ASSERT_NE(var1, nullptr);
   ASSERT_NE(var2, nullptr);
@@ -1153,6 +1154,7 @@ TEST_F(RuleActionParseTest, ActionAlias) {
   ASSERT_NE(var5, nullptr);
   ASSERT_NE(var6, nullptr);
   ASSERT_NE(var7, nullptr);
+  ASSERT_NE(var8, nullptr);
   EXPECT_EQ(var0->subName(), "");
   EXPECT_EQ(var1->subName(), "../../foo.bar.world");
   EXPECT_EQ(var2->subName(), "foo[].bar");
@@ -1161,6 +1163,7 @@ TEST_F(RuleActionParseTest, ActionAlias) {
   EXPECT_EQ(var5->subName(), "../../foo.bar1");
   EXPECT_EQ(var6->subName(), "../../../../../");
   EXPECT_EQ(var7->subName(), "../../../../../foo");
+  EXPECT_EQ(var8->subName(), "../../");
   EXPECT_EQ(var0->parentCount(), 0);
   EXPECT_EQ(var1->parentCount(), 2);
   EXPECT_EQ(var2->parentCount(), 0);
@@ -1169,6 +1172,7 @@ TEST_F(RuleActionParseTest, ActionAlias) {
   EXPECT_EQ(var5->parentCount(), 2);
   EXPECT_EQ(var6->parentCount(), 5);
   EXPECT_EQ(var7->parentCount(), 5);
+  EXPECT_EQ(var8->parentCount(), 2);
   EXPECT_EQ(var0->paths().size(), 0);
   EXPECT_EQ(var1->paths().size(), 3);
   EXPECT_EQ(var2->paths().size(), 2);
@@ -1177,6 +1181,7 @@ TEST_F(RuleActionParseTest, ActionAlias) {
   EXPECT_EQ(var5->paths().size(), 2);
   EXPECT_EQ(var6->paths().size(), 0);
   EXPECT_EQ(var7->paths().size(), 1);
+  EXPECT_EQ(var8->paths().size(), 0);
 
   auto& op = parser.rules()[0].front().chainRule(0)->operators().front();
   EXPECT_EQ(op->literalValue(), "");
@@ -1195,7 +1200,7 @@ TEST_F(RuleActionParseTest, ActionRef) {
   // 4. Test the reference were cleared after parsing is done.
   const std::string rule_directive = R"(
         SecRule ARGS:aaa|ARGS:bbb "bar" "id:1,phase:1,ref:test0=MATCHED_OPTREE,ref:test1=MATCHED_VPTREE../../foo.bar,ref:test2=MATCHED_OPTREE../,msg:'aaa',chain"
-          SecRule test0|test1:world|test0:foo[].bar|test0:foo[].bar{}|test1:../|test1:../bar1|test1:../../../../../|test1:../../../../../foo "@rx %{test2.for.bar}" "id:2,phase:1,msg:'bbb'"
+          SecRule test0|test1:world|test0:foo[].bar|test0:foo[].bar{}|test1:../|test1:../bar1|test1:../../../../../|test1:../../../../../foo|test2:../ "@rx %{test2.for.bar}" "id:2,phase:1,msg:'bbb'"
         SecRule test0|test1:world "baz" "id:3,phase:1,msg:'bbb'")";
 
   auto result = parser.load(rule_directive);
@@ -1205,7 +1210,7 @@ TEST_F(RuleActionParseTest, ActionRef) {
   EXPECT_EQ(parser.rules()[0].size(), 1);
 
   auto& rule_var_pool = parser.rules()[0].front().chainRule(0)->variables();
-  ASSERT_EQ(rule_var_pool.size(), 8);
+  ASSERT_EQ(rule_var_pool.size(), 9);
   Variable::Ref* var0 = dynamic_cast<Variable::Ref*>(rule_var_pool[0].get());
   Variable::Ref* var1 = dynamic_cast<Variable::Ref*>(rule_var_pool[1].get());
   Variable::Ref* var2 = dynamic_cast<Variable::Ref*>(rule_var_pool[2].get());
@@ -1214,6 +1219,7 @@ TEST_F(RuleActionParseTest, ActionRef) {
   Variable::Ref* var5 = dynamic_cast<Variable::Ref*>(rule_var_pool[5].get());
   Variable::Ref* var6 = dynamic_cast<Variable::Ref*>(rule_var_pool[6].get());
   Variable::Ref* var7 = dynamic_cast<Variable::Ref*>(rule_var_pool[7].get());
+  Variable::Ref* var8 = dynamic_cast<Variable::Ref*>(rule_var_pool[8].get());
   ASSERT_NE(var0, nullptr);
   ASSERT_NE(var1, nullptr);
   ASSERT_NE(var2, nullptr);
@@ -1222,6 +1228,7 @@ TEST_F(RuleActionParseTest, ActionRef) {
   ASSERT_NE(var5, nullptr);
   ASSERT_NE(var6, nullptr);
   ASSERT_NE(var7, nullptr);
+  ASSERT_NE(var8, nullptr);
   EXPECT_EQ(var0->subName(), "");
   EXPECT_EQ(var1->subName(), "world");
   EXPECT_EQ(var2->subName(), "foo[].bar");
@@ -1230,10 +1237,11 @@ TEST_F(RuleActionParseTest, ActionRef) {
   EXPECT_EQ(var5->subName(), "../bar1");
   EXPECT_EQ(var6->subName(), "../../../../../");
   EXPECT_EQ(var7->subName(), "../../../../../foo");
+  EXPECT_EQ(var8->subName(), "../");
 
   auto& op = parser.rules()[0].front().chainRule(0)->operators().front();
   EXPECT_EQ(op->literalValue(), "");
-  EXPECT_EQ(op->macro()->literalValue(), "%{Ref.for.bar}");
+  EXPECT_EQ(op->macro()->literalValue(), "%{MATCHED_OPTREE_REF.for.bar}");
   Macro::VariableMacro* op_var_macro = dynamic_cast<Macro::VariableMacro*>(op->macro().get());
   ASSERT_NE(op_var_macro, nullptr);
   EXPECT_EQ(op_var_macro->getVariable()->subName(), "for.bar");


### PR DESCRIPTION
The SecFragmentRule designed to enhance modularity and reusability of rule definitions.
The SecFragmentRule allows users to define fragment rules in the SecLang grammar. And other rule can reference these fragment rules. E.g.,
```
SecFragmentRule name ARGS "@rx hello" "id:2,phase:1"
SecRule REQUEST_URI "@rx world" "id:1,phase:1,chain"
    SecRule fragment:name
```