### PR TITLE
fix(transformation): fix result loss in trim

### DIFF
--- a/src/transformation/trim.cc
+++ b/src/transformation/trim.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  *
  * MIT License (http://opensource.org/licenses/MIT)
  *
@@ -26,13 +26,23 @@
 namespace Wge {
 namespace Transformation {
 bool Trim::evaluate(std::string_view data, std::string& result) const {
-  std::string left_result;
-  auto ret1 = trimLeft(data, left_result);
+  bool changed = false;
 
-  std::string_view right_input = ret1 ? left_result : data;
-  auto ret2 = trimRight(right_input, result);
+  std::string tmp;
+  std::string_view cur = data;
 
-  return ret1 || ret2;
+  if (trimLeft(cur, tmp)) {
+    cur = tmp;
+    changed = true;
+  }
+
+  if (trimRight(cur, result)) {
+    changed = true;
+  } else if (changed) {
+    result.assign(cur);
+  }
+
+  return changed;
 }
 
 std::unique_ptr<StreamState, std::function<void(StreamState*)>> Trim::newStream() const {

--- a/test/transformation/transformation_test.cc
+++ b/test/transformation/transformation_test.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  *
  * MIT License (http://opensource.org/licenses/MIT)
  *
@@ -535,7 +535,9 @@ TEST_F(TransformationTest, trim) {
   const std::vector<TestCase> test_cases = {
       {false, "This is a test", "This is a test"},
       {true, "\t\n\r\f\v\x20 This is a test \t\n\r\f\v\x20", "This is a test"},
-      {true, "\t\n\r\f\v\x20 ", ""}};
+      {true, "\t\n\r\f\v\x20 ", ""},
+      {true, "\t\n\r\f\v\x20 This is a test", "This is a test"},
+      {true, "This is a test\t\n\r\f\v\x20 ", "This is a test"}};
 
   evaluate<Wge::Transformation::Trim>(test_cases);
   evaluateStream<Wge::Transformation::Trim>(test_cases);


### PR DESCRIPTION
When trimLeft succeeds but trimRight fails, trimRight clears the output string, causing the left-trimmed result to be lost.

This change isolates intermediate results so that partial success is preserved correctly. The final output now reflects any successful trim operation instead of being overwritten by a failing step.

Fixes #122