### PR TITLE
fix(antlr4): correctly call CurrentRule::finalize

### DIFF
--- a/src/antlr4/visitor.h
+++ b/src/antlr4/visitor.h
@@ -49,15 +49,6 @@ public:
   }
 
 public:
-  std::any visit(antlr4::tree::ParseTree* tree) override {
-    auto result = Antlr4Gen::SecLangParserBaseVisitor::visit(tree);
-    if (current_rule_) {
-      current_rule_->finalize(true);
-    }
-    return result;
-  }
-
-public:
   std::any visitInclude(Antlr4Gen::SecLangParser::IncludeContext* ctx) override;
 
   // Engine configurations
@@ -1380,6 +1371,7 @@ private:
 private:
   Parser* parser_;
   std::unique_ptr<CurrentRule> current_rule_;
+  Rule* last_rule_{nullptr};
   bool chain_{false};
   bool should_visit_next_child_{true};
   std::unordered_map<std::string, std::string> alias_;


### PR DESCRIPTION
The original implementation failed to store the last created rule, leading to incorrect behavior in subsequent directives. Such as `SecRuleRemoveById` is the last directive, and SecRule is before it, the finalize of SecRule was not called correctly.
Now, we call finalize properly when a rule is created. This ensures that the last created rule is always stored and used for chaining new rules.