### PR TITLE
feat(variable): add current_o/vptree variable

### DIFF
--- a/src/antlr4/SecLangLexer.g4
+++ b/src/antlr4/SecLangLexer.g4
@@ -477,13 +477,19 @@ VAR_IP: [iI][pP];
 VAR_USER: [uU][sS][eE][rR];
 VAR_PTREE:
 	[pP][tT][rR][eE][eE] -> pushMode(ModeSecRuleVariableNamePtree);
+VAR_GTX: [gG][tT][xX];
 VAR_MATCHED_VPTREE:
 	[mM][aA][tT][cC][hH][eE][dD]'_' [vV][pP][tT][rR][eE][eE] -> pushMode(
 		ModeSecRuleVariableNamePtree);
 VAR_MATCHED_OPTREE:
 	[mM][aA][tT][cC][hH][eE][dD]'_' [oO][pP][tT][rR][eE][eE] -> pushMode(
 		ModeSecRuleVariableNamePtree);
-VAR_GTX: [gG][tT][xX];
+VAR_CURRENT_VPTREE:
+	[cC][uU][rR][rR][eE][nN][tT]'_' [vV][pP][tT][rR][eE][eE] -> pushMode(
+		ModeSecRuleVariableNamePtree);
+VAR_CURRENT_OPTREE:
+	[cC][uU][rR][rR][eE][nN][tT]'_' [oO][pP][tT][rR][eE][eE] -> pushMode(
+		ModeSecRuleVariableNamePtree);
 VAR_ALIAS_OR_REF:
 	[a-zA-Z_][0-9a-zA-Z_]* -> pushMode(ModeSecRuleVariableNamePtree);
 ModeSecRuleVariableName_WS: WS -> skip, popMode;

--- a/src/antlr4/SecLangParser.g4
+++ b/src/antlr4/SecLangParser.g4
@@ -1054,6 +1054,8 @@ extension_variable:
 	| variable_gtx
 	| variable_matched_vptree
 	| variable_matched_optree
+	| variable_current_vptree
+	| variable_current_optree
 	| variable_alias_or_ref;
 variable_ptree:
 	NOT? VAR_COUNT? VAR_PTREE (COLON | DOT) variable_ptree_expression;
@@ -1082,6 +1084,16 @@ variable_matched_vptree:
 	)?;
 variable_matched_optree:
 	NOT? VAR_COUNT? VAR_MATCHED_OPTREE (
+		((COLON | DOT) variable_ptree_expression)
+		| (PARENT+ variable_ptree_expression?)
+	)?;
+variable_current_vptree:
+	NOT? VAR_COUNT? VAR_CURRENT_VPTREE (
+		((COLON | DOT) variable_ptree_expression)
+		| (PARENT+ variable_ptree_expression?)
+	)?;
+variable_current_optree:
+	NOT? VAR_COUNT? VAR_CURRENT_OPTREE (
 		((COLON | DOT) variable_ptree_expression)
 		| (PARENT+ variable_ptree_expression?)
 	)?;

--- a/src/antlr4/visitor.cc
+++ b/src/antlr4/visitor.cc
@@ -961,6 +961,16 @@ std::any Visitor::visitVariable_matched_optree(
   return appendVariable<Variable::MatchedOPTree>(ctx);
 }
 
+std::any Visitor::visitVariable_current_vptree(
+    Antlr4Gen::SecLangParser::Variable_current_vptreeContext* ctx) {
+  return appendVariable<Variable::CurrentVPTree>(ctx);
+}
+
+std::any Visitor::visitVariable_current_optree(
+    Antlr4Gen::SecLangParser::Variable_current_optreeContext* ctx) {
+  return appendVariable<Variable::CurrentOPTree>(ctx);
+}
+
 std::any
 Visitor::visitVariable_alias_or_ref(Antlr4Gen::SecLangParser::Variable_alias_or_refContext* ctx) {
   // Check if alias or reference is defined

--- a/src/antlr4/visitor.h
+++ b/src/antlr4/visitor.h
@@ -26,6 +26,8 @@
 #include "../common/empty_string.h"
 #include "../macro/macro_include.h"
 #include "../operator/pm_from_file.h"
+#include "../variable/current_optree.h"
+#include "../variable/current_vptree.h"
 #include "../variable/matched_optree.h"
 #include "../variable/matched_vptree.h"
 #include "../variable/ptree.h"
@@ -463,6 +465,10 @@ public:
       Antlr4Gen::SecLangParser::Variable_matched_vptreeContext* ctx) override;
   std::any visitVariable_matched_optree(
       Antlr4Gen::SecLangParser::Variable_matched_optreeContext* ctx) override;
+  std::any visitVariable_current_vptree(
+      Antlr4Gen::SecLangParser::Variable_current_vptreeContext* ctx) override;
+  std::any visitVariable_current_optree(
+      Antlr4Gen::SecLangParser::Variable_current_optreeContext* ctx) override;
   std::any
   visitVariable_alias_or_ref(Antlr4Gen::SecLangParser::Variable_alias_or_refContext* ctx) override;
 
@@ -897,9 +903,13 @@ private:
     std::unique_ptr<Macro::VariableMacro> sub_name_macro;
     if constexpr (std::is_same_v<VarT, Variable::PTree> ||
                   std::is_same_v<VarT, Variable::MatchedOPTree> ||
-                  std::is_same_v<VarT, Variable::MatchedVPTree>) {
+                  std::is_same_v<VarT, Variable::MatchedVPTree> ||
+                  std::is_same_v<VarT, Variable::CurrentOPTree> ||
+                  std::is_same_v<VarT, Variable::CurrentVPTree>) {
       if constexpr (std::is_same_v<VarT, Variable::MatchedOPTree> ||
-                    std::is_same_v<VarT, Variable::MatchedVPTree>) {
+                    std::is_same_v<VarT, Variable::MatchedVPTree> ||
+                    std::is_same_v<VarT, Variable::CurrentOPTree> ||
+                    std::is_same_v<VarT, Variable::CurrentVPTree>) {
         // The subname still needs the parent node information to prevent their full name from
         // conflicting. Otherwise, there will be fail append to list of variables caused by same
         // full name.

--- a/src/variable/current_optree.h
+++ b/src/variable/current_optree.h
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
+ *
+ * MIT License (http://opensource.org/licenses/MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "matched_ptree_base.h"
+
+#include "../macro/variable_macro.h"
+#include "../rule.h"
+
+namespace Wge {
+namespace Variable {
+class CurrentOPTree final : public MatchedPTreeBase {
+  DECLARE_VIRABLE_NAME(CURRENT_OPTREE);
+
+public:
+  CurrentOPTree(std::string&& sub_name, bool is_not, bool is_counter,
+                std::string_view curr_rule_file_path)
+      : MatchedPTreeBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  CurrentOPTree(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                bool is_counter, std::string_view curr_rule_file_path)
+      : MatchedPTreeBase("", is_not, is_counter, curr_rule_file_path) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
+
+public:
+  const std::vector<const Common::PropertyTree*>&
+  getAllMatchedPtrees(Transaction& t) const override {
+    int rule_chain_index = -1;
+    if (t.getCurrentEvaluateRule()) {
+      rule_chain_index = t.getCurrentEvaluateRule()->chainIndex();
+    }
+
+    return t.getMatchedOPTrees(rule_chain_index);
+  }
+
+  const Common::PropertyTree* getMatchedPTree(Transaction& t) const override {
+    auto& all_matched_optrees = getAllMatchedPtrees(t);
+    if (all_matched_optrees.empty()) {
+      return nullptr;
+    }
+
+    auto matched_optree = all_matched_optrees.back();
+
+    for (int i = 0; i < parent_count_; ++i) {
+      matched_optree = matched_optree->parent();
+      if (!matched_optree) {
+        WGE_LOG_WARN("CurrentOPTree parent is nullptr!");
+        break;
+      }
+    }
+
+    return matched_optree;
+  }
+};
+} // namespace Variable
+} // namespace Wge

--- a/src/variable/current_vptree.h
+++ b/src/variable/current_vptree.h
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
+ *
+ * MIT License (http://opensource.org/licenses/MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "matched_ptree_base.h"
+
+#include "../macro/variable_macro.h"
+#include "../rule.h"
+
+namespace Wge {
+namespace Variable {
+class CurrentVPTree final : public MatchedPTreeBase {
+  DECLARE_VIRABLE_NAME(CURRENT_VPTREE);
+
+public:
+  CurrentVPTree(std::string&& sub_name, bool is_not, bool is_counter,
+                std::string_view curr_rule_file_path)
+      : MatchedPTreeBase(std::move(sub_name), is_not, is_counter, curr_rule_file_path) {}
+
+  CurrentVPTree(std::unique_ptr<Macro::VariableMacro>&& sub_name_macro, bool is_not,
+                bool is_counter, std::string_view curr_rule_file_path)
+      : MatchedPTreeBase("", is_not, is_counter, curr_rule_file_path) {
+    // Does not support sub_name macro
+    UNREACHABLE();
+  }
+
+public:
+  const std::vector<const Common::PropertyTree*>&
+  getAllMatchedPtrees(Transaction& t) const override {
+    int rule_chain_index = -1;
+    if (t.getCurrentEvaluateRule()) {
+      rule_chain_index = t.getCurrentEvaluateRule()->chainIndex();
+    }
+
+    return t.getMatchedVPTrees(rule_chain_index);
+  }
+
+  const Common::PropertyTree* getMatchedPTree(Transaction& t) const override {
+    auto& all_matched_vptrees = getAllMatchedPtrees(t);
+    if (all_matched_vptrees.empty()) {
+      return nullptr;
+    }
+
+    auto matched_vptree = all_matched_vptrees.back();
+
+    for (int i = 0; i < parent_count_; ++i) {
+      matched_vptree = matched_vptree->parent();
+      if (!matched_vptree) {
+        WGE_LOG_WARN("CurrentVPTree parent is nullptr!");
+        break;
+      }
+    }
+
+    return matched_vptree;
+  }
+};
+} // namespace Variable
+} // namespace Wge

--- a/src/variable/variables_include.h
+++ b/src/variable/variables_include.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  *
  * MIT License (http://opensource.org/licenses/MIT)
  *
@@ -28,6 +28,8 @@
 #include "args_post.h"
 #include "args_post_names.h"
 #include "auth_type.h"
+#include "current_optree.h"
+#include "current_vptree.h"
 #include "duration.h"
 #include "env.h"
 #include "files.h"

--- a/test/parser/rule_variable_parse_test.cc
+++ b/test/parser/rule_variable_parse_test.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  *
  * MIT License (http://opensource.org/licenses/MIT)
  *
@@ -210,6 +210,78 @@ TEST_F(RuleVariableParseTest, MatchedVPTree) {
   const auto* variable1 = dynamic_cast<const Variable::MatchedVPTree*>(variables[1].get());
   const auto* variable2 = dynamic_cast<const Variable::MatchedVPTree*>(variables[2].get());
   const auto* variable3 = dynamic_cast<const Variable::MatchedVPTree*>(variables[3].get());
+  ASSERT_NE(variable0, nullptr);
+  ASSERT_NE(variable1, nullptr);
+  ASSERT_NE(variable2, nullptr);
+  ASSERT_NE(variable3, nullptr);
+
+  EXPECT_EQ(variable0->parentCount(), 2);
+  EXPECT_EQ(variable0->subName(), "../../");
+  EXPECT_EQ(variable0->paths().size(), 0);
+
+  EXPECT_EQ(variable1->parentCount(), 0);
+  EXPECT_EQ(variable1->subName(), "foo.bar");
+  EXPECT_EQ(variable1->paths().size(), 2);
+
+  EXPECT_EQ(variable2->parentCount(), 1);
+  EXPECT_EQ(variable2->subName(), "../hello.world");
+  EXPECT_EQ(variable2->paths().size(), 2);
+
+  EXPECT_EQ(variable3->parentCount(), 0);
+  EXPECT_EQ(variable3->subName(), "");
+  EXPECT_EQ(variable3->paths().size(), 0);
+}
+
+TEST_F(RuleVariableParseTest, CurrentOPTree) {
+  const std::string directive =
+      R"(SecRule CURRENT_OPTREE../../|CURRENT_OPTREE:foo.bar|CURRENT_OPTREE../hello.world|CURRENT_OPTREE "foo" "id:1,phase:1")";
+
+  Antlr4::Parser parser;
+  auto result = parser.load(directive);
+  ASSERT_TRUE(result.has_value());
+
+  auto& variables = parser.rules()[0].back().variables();
+  EXPECT_EQ(variables.size(), 4);
+  const auto* variable0 = dynamic_cast<const Variable::CurrentOPTree*>(variables[0].get());
+  const auto* variable1 = dynamic_cast<const Variable::CurrentOPTree*>(variables[1].get());
+  const auto* variable2 = dynamic_cast<const Variable::CurrentOPTree*>(variables[2].get());
+  const auto* variable3 = dynamic_cast<const Variable::CurrentOPTree*>(variables[3].get());
+  ASSERT_NE(variable0, nullptr);
+  ASSERT_NE(variable1, nullptr);
+  ASSERT_NE(variable2, nullptr);
+  ASSERT_NE(variable3, nullptr);
+
+  EXPECT_EQ(variable0->parentCount(), 2);
+  EXPECT_EQ(variable0->subName(), "../../");
+  EXPECT_EQ(variable0->paths().size(), 0);
+
+  EXPECT_EQ(variable1->parentCount(), 0);
+  EXPECT_EQ(variable1->subName(), "foo.bar");
+  EXPECT_EQ(variable1->paths().size(), 2);
+
+  EXPECT_EQ(variable2->parentCount(), 1);
+  EXPECT_EQ(variable2->subName(), "../hello.world");
+  EXPECT_EQ(variable2->paths().size(), 2);
+
+  EXPECT_EQ(variable3->parentCount(), 0);
+  EXPECT_EQ(variable3->subName(), "");
+  EXPECT_EQ(variable3->paths().size(), 0);
+}
+
+TEST_F(RuleVariableParseTest, CurrentVPTree) {
+  const std::string directive =
+      R"(SecRule CURRENT_VPTREE../../|CURRENT_VPTREE:foo.bar|CURRENT_VPTREE../hello.world|CURRENT_VPTREE "foo" "id:1,phase:1")";
+
+  Antlr4::Parser parser;
+  auto result = parser.load(directive);
+  ASSERT_TRUE(result.has_value());
+
+  auto& variables = parser.rules()[0].back().variables();
+  EXPECT_EQ(variables.size(), 4);
+  const auto* variable0 = dynamic_cast<const Variable::CurrentVPTree*>(variables[0].get());
+  const auto* variable1 = dynamic_cast<const Variable::CurrentVPTree*>(variables[1].get());
+  const auto* variable2 = dynamic_cast<const Variable::CurrentVPTree*>(variables[2].get());
+  const auto* variable3 = dynamic_cast<const Variable::CurrentVPTree*>(variables[3].get());
   ASSERT_NE(variable0, nullptr);
   ASSERT_NE(variable1, nullptr);
   ASSERT_NE(variable2, nullptr);


### PR DESCRIPTION
Add support for current_optree and current_vptree variables to access the most-recently matched property tree nodes in the current rule. Different from matched_optree and matched_vptree which access most-recently matched property tree nodes in the parent rule, current_optree and current_vptree provide access to the nodes matched in the current rule itself.