### PR TITLE
fix(rule): reset transform-state in multi-match

### DIFF
--- a/src/rule.cc
+++ b/src/rule.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 Stone Rhino and contributors.
+ * Copyright (c) 2024-2026 Stone Rhino and contributors.
  *
  * MIT License (http://opensource.org/licenses/MIT)
  *
@@ -582,12 +582,12 @@ bool Rule::evaluateWithMultiMatch(Transaction& t) const {
     size_t curr_transform_index = 0;
 
     // Evaluate each variable result
-    transformed_value.clear();
-    transform_list.clear();
     const Common::EvaluateElement* evaluated_value = nullptr;
     for (size_t i = 0; i < result.size();) {
       if (evaluated_value == nullptr) {
         evaluated_value = &result[i];
+        transformed_value.clear();
+        transform_list.clear();
       }
 
       // Evaluate the operator


### PR DESCRIPTION
When evaluating collection-type variables in evaluateWithMultiMatch, the transformation-related intermediate state (transform_list and transformed_value) could persist across iterations under certain execution paths.

If a previous iteration executed transformations but did not produce a match, the stale transformation state could leak into the next iteration and pollute the matched_var constructed for a subsequent successful match.

This change ensures that transformation state is properly isolated and reset per iteration, so matched_var only contains transformation data corresponding to the variable that actually triggered the match.

Fixes #132